### PR TITLE
Harden insert_equation argument contract

### DIFF
--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -2521,7 +2521,7 @@ actor WordMCPServer {
             // 7.3 數學公式
             Tool(
                 name: "insert_equation",
-                description: "插入數學公式（結構化 OMML，可在 Word native equation editor 雙擊編輯）。v3.2+ 的 latex: 支援 LaTeX 子集（見下方 latex 參數描述完整 token 清單）；components: 為 JSON tree fallback，給超出 LaTeX 子集的進階用法。必須提供 components 或 latex 其中之一。v3.16.0+ display mode 同時傳多個 anchor 會 return 「Error: insert_equation: received conflicting anchors: ...」（先前版本是 silent priority winner）；inline mode 仍 reject 所有 anchor（語意 ambiguous）。",
+                description: "插入數學公式（結構化 OMML，可在 Word native equation editor 雙擊編輯）。v3.2+ 的 latex: 支援 LaTeX 子集（見下方 latex 參數描述完整 token 清單）；components: 為 JSON tree fallback，給超出 LaTeX 子集的進階用法。必須提供 components 或 latex 其中之一。MCP 工具層 display_mode 預設 true（區塊公式；OOXMLSwift lib API 的預設值不同）。v3.16.0+ display mode 同時傳多個 anchor 會 return 「Error: insert_equation: received conflicting anchors: ...」（先前版本是 silent priority winner）；inline mode 仍 reject 所有 anchor（語意 ambiguous）。",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -2539,7 +2539,7 @@ actor WordMCPServer {
                         ]),
                         "display_mode": .object([
                             "type": .string("boolean"),
-                            "description": .string("是否為獨立區塊（true，預設）或行內（false）")
+                            "description": .string("是否為獨立區塊（true，MCP 工具層預設）或行內（false）。注意：底層 OOXMLSwift lib API 的預設值為 false；MCP 因 agent 常用區塊公式而保留 true。")
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
@@ -8840,6 +8840,11 @@ actor WordMCPServer {
     ///   uppercase / variants), and common operators. Anything else returns
     ///   an error naming the unrecognized token. See latex-math-swift README
     ///   for the canonical macro list.
+    ///
+    /// MCP defaults `display_mode` to true because agent callers normally want
+    /// block equations. That intentionally differs from the lower-level
+    /// OOXMLSwift lib default, which preserves inline behavior for direct API
+    /// callers.
     private func insertEquation(args: [String: Value]) async throws -> String {
         guard let docId = args["doc_id"]?.stringValue else {
             throw WordError.missingParameter("doc_id")
@@ -8957,6 +8962,9 @@ actor WordMCPServer {
             location = .beforeText(beforeText, instance: textInstance)
             anchorInfo = "before text '\(beforeText)' (instance \(textInstance))"
         } else {
+            // Display mode with no explicit anchor appends at end by passing
+            // body.children.count. The throwing lib insert accepts idx == count
+            // as append-at-end, while larger indices still return out-of-range.
             let insertIdx = paragraphIndex ?? doc.body.children.count
             location = .paragraphIndex(insertIdx)
             anchorInfo = "at index \(insertIdx)"
@@ -9005,10 +9013,7 @@ actor WordMCPServer {
                 // `paragraph_index`. The pre-check above already rejected
                 // inline + nil paragraph_index, so `location` is guaranteed
                 // to be `.paragraphIndex(idx)` with a non-nil idx.
-                guard case .paragraphIndex(let idx) = location else {
-                    // Defensive: pre-check should have caught this.
-                    throw InsertLocationError.inlineModeRequiresParagraphIndex
-                }
+                let idx = paragraphIndex!
                 // Bounds check matches lib's pattern at Document.swift:3990-3997
                 // (#91 Defect 2): count only top-level `.paragraph` body
                 // children, NOT recursing into block-level SDTs.
@@ -9043,9 +9048,6 @@ actor WordMCPServer {
             return "Error: insert_equation: image rId '\(rId)' not found"
         } catch let InsertLocationError.textNotFound(searchText, instance) {
             return "Error: insert_equation: text '\(searchText)' not found (instance \(instance))"
-        } catch InsertLocationError.inlineModeRequiresParagraphIndex {
-            // Defensive: explicit pre-check above should have caught this.
-            return "Error: insert_equation: inline mode requires paragraph_index anchor"
         } catch let InsertLocationError.invalidParagraphIndex(idx) {
             return "Error: insert_equation: paragraph_index \(idx) out of range"
         }

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -2543,7 +2543,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("body.children 索引（從 0 開始；計入 tables / SDTs / bookmarkMarker / rawBlockElement，**不**等同於 get_paragraphs 回傳的 paragraph-only count）。display mode 下若搭配 anchor，anchor 優先；inline 模式直接以此索引插入。lib API 在 #61 / #69 系列已對齊到 body.children index；參數命名沿用「paragraph_index」是歷史遺留，跨工具語意統一見 PsychQuant/ooxml-swift#10。")
+                            "description": .string("display_mode=true：body.children 插入索引（從 0 開始；計入 tables / SDTs / bookmarkMarker / rawBlockElement，**不**等同於 get_paragraphs 回傳的 paragraph-only count），若搭配其他 anchor 則 anchor 衝突會回錯。display_mode=false：top-level `.paragraph` ordinal（從 0 開始；不計入 tables / SDTs / bookmarkMarker / rawBlockElement），且 inline 模式沒有其他 anchor 時必填；inline 會把 OMML run append 到該既有段落。參數命名沿用「paragraph_index」是歷史遺留，跨工具語意統一見 PsychQuant/ooxml-swift#10。")
                         ]),
                         "into_table_cell": .object([
                             "type": .string("object"),
@@ -8855,6 +8855,10 @@ actor WordMCPServer {
         // which produces broken plain-text OOXML — see Insert step below for
         // full rationale. Path origin is preserved in error messages but the
         // insertion mechanic is unified.
+        if args["components"] != nil && args["latex"] != nil {
+            return "Error: insert_equation: pass either 'components' (JSON tree) OR 'latex' (LaTeX subset), not both"
+        }
+
         let components: [MathComponent]
         if let componentsValue = args["components"] {
             do {
@@ -8880,7 +8884,15 @@ actor WordMCPServer {
             return "Error: insert_equation: either 'components' (JSON tree) or 'latex' (LaTeX subset) argument required"
         }
 
-        let displayMode = args["display_mode"]?.boolValue ?? true
+        let displayMode: Bool
+        if let displayModeValue = args["display_mode"] {
+            guard let bool = displayModeValue.boolValue else {
+                return "Error: insert_equation: display_mode must be a boolean true/false, not a string or other JSON type"
+            }
+            displayMode = bool
+        } else {
+            displayMode = true
+        }
         let paragraphIndex = args["paragraph_index"]?.intValue
         let afterText = args["after_text"]?.stringValue
         let beforeText = args["before_text"]?.stringValue

--- a/Tests/CheWordMCPTests/Issue98InsertEquationLibBypassTests.swift
+++ b/Tests/CheWordMCPTests/Issue98InsertEquationLibBypassTests.swift
@@ -478,6 +478,53 @@ final class Issue98InsertEquationLibBypassTests: XCTestCase {
         )
     }
 
+    // MARK: - Issues 108/109/110: follow-up docs and dead-code cleanup
+
+    func testDisplayModeSchemaDocumentsMCPDefaultDivergence() throws {
+        let source = try serverSource()
+        guard let toolStart = source.range(
+            of: #"Tool\(\s*\n\s*name: "insert_equation""#,
+            options: .regularExpression
+        ) else {
+            XCTFail("could not locate insert_equation tool schema")
+            return
+        }
+
+        let toolSource = String(source[toolStart.lowerBound...])
+        XCTAssertTrue(
+            toolSource.contains("MCP 工具層 display_mode 預設 true")
+                && toolSource.contains("OOXMLSwift lib API 的預設值不同"),
+            "insert_equation tool description must document the MCP-vs-lib display_mode default divergence"
+        )
+        XCTAssertTrue(
+            toolSource.contains("底層 OOXMLSwift lib API 的預設值為 false")
+                && toolSource.contains("MCP 因 agent 常用區塊公式而保留 true"),
+            "display_mode property schema must explain why MCP keeps default true while the lib default is false"
+        )
+    }
+
+    func testHandlerDocumentsDisplayAppendFallback() throws {
+        let source = try serverSource()
+        XCTAssertTrue(
+            source.contains("Display mode with no explicit anchor appends at end by passing")
+                && source.contains("body.children.count")
+                && source.contains("as append-at-end"),
+            "handler must document display-mode + nil paragraph_index append fallback semantics"
+        )
+    }
+
+    func testServerNoLongerThrowsOrCatchesDeadInlineModeRequiresParagraphIndex() throws {
+        let source = try serverSource()
+        XCTAssertFalse(
+            source.contains("throw InsertLocationError.inlineModeRequiresParagraphIndex"),
+            "insert_equation handler should not throw the unreachable inlineModeRequiresParagraphIndex defensive path"
+        )
+        XCTAssertFalse(
+            source.contains("catch InsertLocationError.inlineModeRequiresParagraphIndex"),
+            "insert_equation handler should not keep the unreachable inlineModeRequiresParagraphIndex catch arm"
+        )
+    }
+
     // MARK: - Helpers
 
     private func textOf(_ r: CallTool.Result) -> String {

--- a/Tests/CheWordMCPTests/Issue98InsertEquationLibBypassTests.swift
+++ b/Tests/CheWordMCPTests/Issue98InsertEquationLibBypassTests.swift
@@ -379,12 +379,127 @@ final class Issue98InsertEquationLibBypassTests: XCTestCase {
         )
     }
 
+    // MARK: - Issue 105/106/107: argument contract hardening
+
+    func testInsertEquationRejectsComponentsAndLatexTogether() async throws {
+        let url = try minimalDocxFiveParas()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("e106")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "insert_equation",
+            arguments: [
+                "doc_id": .string("e106"),
+                "components": .object([
+                    "type": .string("run"),
+                    "text": .string("component-x")
+                ]),
+                "latex": .string("latex-y")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertFalse(
+            txt.contains("Inserted equation"),
+            "components + latex conflict must not silently choose one path; got: \(txt)"
+        )
+        XCTAssertTrue(
+            txt.contains("components") && txt.contains("latex") && txt.lowercased().contains("not both"),
+            "expected conflict error mentioning components, latex, and not both; got: \(txt)"
+        )
+    }
+
+    func testInsertEquationRejectsStringDisplayMode() async throws {
+        let url = try minimalDocxFiveParas()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("e107")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "insert_equation",
+            arguments: [
+                "doc_id": .string("e107"),
+                "latex": .string("x"),
+                "display_mode": .string("false")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertFalse(
+            txt.contains("Inserted equation"),
+            "string display_mode must not fail open to default display mode; got: \(txt)"
+        )
+        XCTAssertTrue(
+            txt.contains("display_mode") && txt.lowercased().contains("boolean"),
+            "expected type error mentioning display_mode and boolean; got: \(txt)"
+        )
+    }
+
+    func testParagraphIndexSchemaDocumentsDisplayAndInlineOrdinals() throws {
+        let source = try serverSource()
+        guard let toolStart = source.range(
+            of: #"Tool\(\s*\n\s*name: "insert_equation""#,
+            options: .regularExpression
+        ) else {
+            XCTFail("could not locate insert_equation tool schema")
+            return
+        }
+
+        let toolSource = source[toolStart.lowerBound...]
+        guard let paragraphStart = toolSource.range(of: #""paragraph_index": .object(["#),
+              let nextProperty = toolSource[paragraphStart.lowerBound...].range(
+                of: #""into_table_cell": .object(["#
+              ) else {
+            XCTFail("could not locate insert_equation paragraph_index schema block")
+            return
+        }
+
+        let snippet = String(toolSource[paragraphStart.lowerBound..<nextProperty.lowerBound])
+        XCTAssertTrue(
+            snippet.contains("display_mode=true") && snippet.contains("body.children"),
+            "display mode schema must preserve body.children insertion-index contract; got: \(snippet)"
+        )
+        XCTAssertTrue(
+            snippet.contains("display_mode=false")
+                && snippet.contains("top-level `.paragraph`")
+                && snippet.contains("不計入 tables / SDTs"),
+            "inline mode schema must document paragraph-only ordinal contract; got: \(snippet)"
+        )
+        XCTAssertFalse(
+            snippet.contains("inline 模式直接以此索引插入"),
+            "schema must not imply inline mode directly uses body.children ordinal; got: \(snippet)"
+        )
+    }
+
     // MARK: - Helpers
 
     private func textOf(_ r: CallTool.Result) -> String {
         r.content.compactMap { item -> String? in
             if case let .text(t, _, _) = item { return t } else { return nil }
         }.joined(separator: "\n")
+    }
+
+    private func serverSource() throws -> String {
+        let serverPath: URL = {
+            if let src = ProcessInfo.processInfo.environment["SOURCE_ROOT"] {
+                return URL(fileURLWithPath: src).appendingPathComponent("Sources/CheWordMCP/Server.swift")
+            }
+            var url = URL(fileURLWithPath: #filePath)
+            while url.pathComponents.count > 1 {
+                url = url.deletingLastPathComponent()
+                let candidate = url.appendingPathComponent("Sources/CheWordMCP/Server.swift")
+                if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            }
+            return URL(fileURLWithPath: "/dev/null")
+        }()
+        return try String(contentsOf: serverPath, encoding: .utf8)
     }
 
     /// Extract `word/document.xml` from a .docx (zip) at the given path.


### PR DESCRIPTION
## Summary

- Reject `insert_equation` calls that pass both `components` and `latex` instead of silently choosing `components`.
- Reject non-boolean `display_mode` values instead of falling back to display mode.
- Clarify `paragraph_index` schema: display mode uses `body.children` insertion index; inline mode uses top-level `.paragraph` ordinal.
- Add regression coverage for #105, #106, and #107 in the existing `Issue98InsertEquationLibBypassTests` suite.

## Tests

- `swift test --filter Issue98InsertEquationLibBypassTests`
- `swift test`

Refs #105, #106, #107
