### PR TITLE
Add comment review workflow helpers

### DIFF
--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -2185,6 +2185,35 @@ actor WordMCPServer {
                         "source_path": .object([
                             "type": .string("string"),
                             "description": .string("檔案路徑（Direct Mode，免開啟）")
+                        ]),
+                        "include_context": .object([
+                            "type": .string("boolean"),
+                            "description": .string("是否回傳 JSON context preview（預設 false，維持原文字輸出）")
+                        ]),
+                        "context_chars": .object([
+                            "type": .string("integer"),
+                            "description": .string("include_context=true 時，anchor 前後各回傳多少字（預設 50）")
+                        ])
+                    ])
+                ])
+            ),
+            Tool(
+                name: "find_unresolved_comments",
+                description: "列出尚未 resolved 的頂層註解（支援 Direct Mode，可包含 anchor context）",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("文件識別碼（Session Mode）")
+                        ]),
+                        "source_path": .object([
+                            "type": .string("string"),
+                            "description": .string("檔案路徑（Direct Mode，免開啟）")
+                        ]),
+                        "context_chars": .object([
+                            "type": .string("integer"),
+                            "description": .string("anchor 前後各回傳多少字（預設 50）")
                         ])
                     ])
                 ])
@@ -2672,8 +2701,50 @@ actor WordMCPServer {
 
             // 8.1 註解回覆
             Tool(
+                name: "add_comment_reply",
+                description: "回覆現有註解；支援 template/vars 與 resolve=true 一次完成回覆加標記已解決",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("文件識別碼")
+                        ]),
+                        "comment_id": .object([
+                            "type": .string("integer"),
+                            "description": .string("要回覆的註解 ID")
+                        ]),
+                        "reply_text": .object([
+                            "type": .string("string"),
+                            "description": .string("回覆內容；也可用 text alias")
+                        ]),
+                        "text": .object([
+                            "type": .string("string"),
+                            "description": .string("reply_text 的 alias")
+                        ]),
+                        "template": .object([
+                            "type": .string("string"),
+                            "description": .string("內建 template：fix_done, noted, wontfix, more_info_needed")
+                        ]),
+                        "vars": .object([
+                            "type": .string("object"),
+                            "description": .string("template 變數，例如 { commit_sha, issue_number }")
+                        ]),
+                        "resolve": .object([
+                            "type": .string("boolean"),
+                            "description": .string("true 時新增 reply 後同步標記該 comment resolved")
+                        ]),
+                        "author": .object([
+                            "type": .string("string"),
+                            "description": .string("回覆者名稱（預設 'User'）")
+                        ])
+                    ]),
+                    "required": .array([.string("doc_id"), .string("comment_id")])
+                ])
+            ),
+            Tool(
                 name: "reply_to_comment",
-                description: "回覆現有的註解",
+                description: "回覆現有的註解（舊名；同 add_comment_reply，保留 parent_comment_id/text alias）",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -2692,9 +2763,21 @@ actor WordMCPServer {
                         "author": .object([
                             "type": .string("string"),
                             "description": .string("回覆者名稱（預設 'Author'）")
+                        ]),
+                        "template": .object([
+                            "type": .string("string"),
+                            "description": .string("內建 template：fix_done, noted, wontfix, more_info_needed")
+                        ]),
+                        "vars": .object([
+                            "type": .string("object"),
+                            "description": .string("template 變數")
+                        ]),
+                        "resolve": .object([
+                            "type": .string("boolean"),
+                            "description": .string("true 時新增 reply 後同步標記該 comment resolved")
                         ])
                     ]),
-                    "required": .array([.string("doc_id"), .string("parent_comment_id"), .string("text")])
+                    "required": .array([.string("doc_id")])
                 ])
             ),
             Tool(
@@ -2717,6 +2800,24 @@ actor WordMCPServer {
                         ])
                     ]),
                     "required": .array([.string("doc_id"), .string("comment_id")])
+                ])
+            ),
+            Tool(
+                name: "bulk_resolve_comments",
+                description: "批次標記多個註解為 resolved；不中斷於單筆失敗，回傳成功數與 failed 清單",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("文件識別碼")
+                        ]),
+                        "comment_ids": .object([
+                            "type": .string("array"),
+                            "description": .string("要標記為 resolved 的註解 ID 陣列")
+                        ])
+                    ]),
+                    "required": .array([.string("doc_id"), .string("comment_ids")])
                 ])
             ),
 
@@ -3618,6 +3719,35 @@ actor WordMCPServer {
                         ])
                     ]),
                     "required": .array([.string("query")])
+                ])
+            ),
+            Tool(
+                name: "find_inline_math_gaps",
+                description: "掃描段落中疑似遺失 inline math symbol 的連續空白 gap，回傳位置與前後文（支援 Direct Mode）",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("文件識別碼（Session Mode）")
+                        ]),
+                        "source_path": .object([
+                            "type": .string("string"),
+                            "description": .string("檔案路徑（Direct Mode，免開啟）")
+                        ]),
+                        "min_gap_chars": .object([
+                            "type": .string("integer"),
+                            "description": .string("連續多少空白才算候選 gap（預設 2）")
+                        ]),
+                        "context_chars": .object([
+                            "type": .string("integer"),
+                            "description": .string("gap 前後各回傳多少字（預設 30）")
+                        ]),
+                        "exclude_table_captions": .object([
+                            "type": .string("boolean"),
+                            "description": .string("是否排除表格 caption 樣式段落（預設 true）")
+                        ])
+                    ])
                 ])
             ),
             Tool(
@@ -5866,6 +5996,10 @@ actor WordMCPServer {
             return try await deleteComment(args: args)
         case "list_comments":
             return try await listComments(args: args)
+        case "find_unresolved_comments":
+            return try await findUnresolvedComments(args: args)
+        case "bulk_resolve_comments":
+            return try await bulkResolveComments(args: args)
         case "enable_track_changes":
             return try await enableTrackChanges(args: args)
         case "disable_track_changes":
@@ -5912,7 +6046,7 @@ actor WordMCPServer {
             return try await setTextEffect(args: args)
 
         // 8.1 註解回覆與解析
-        case "reply_to_comment":
+        case "add_comment_reply", "reply_to_comment":
             return try await replyToComment(args: args)
         case "resolve_comment":
             return try await resolveComment(args: args)
@@ -6032,6 +6166,8 @@ actor WordMCPServer {
             return try await getDocumentText(args: args)
         case "search_text":
             return try await searchText(args: args)
+        case "find_inline_math_gaps":
+            return try await findInlineMathGaps(args: args)
         case "search_text_batch":
             return try await searchTextBatch(args: args)
         case "list_hyperlinks":
@@ -8547,12 +8683,26 @@ actor WordMCPServer {
         return "Deleted comment \(commentId)"
     }
 
+    private struct CommentContext {
+        let anchoredRunText: String?
+        let contextBefore: String?
+        let contextAfter: String?
+        let flattenedText: String?
+    }
+
     private func listComments(args: [String: Value]) async throws -> String {
         let (doc, _) = try await resolveDocument(args: args)
 
-        let comments = doc.getComments()
+        let comments = doc.getCommentsFull()
         if comments.isEmpty {
             return "No comments in document"
+        }
+
+        let includeContext = args["include_context"]?.boolValue ?? false
+        let contextChars = max(0, args["context_chars"]?.intValue ?? 50)
+
+        if includeContext {
+            return commentJSON(comments: comments, in: doc, contextChars: contextChars)
         }
 
         let dateFormatter = DateFormatter()
@@ -8564,6 +8714,108 @@ actor WordMCPServer {
         }
 
         return result
+    }
+
+    private func findUnresolvedComments(args: [String: Value]) async throws -> String {
+        let (doc, _) = try await resolveDocument(args: args)
+        let contextChars = max(0, args["context_chars"]?.intValue ?? 50)
+        let unresolved = doc.getCommentsFull().filter { !$0.done && $0.parentId == nil }
+        return commentJSON(comments: unresolved, in: doc, contextChars: contextChars)
+    }
+
+    private func commentJSON(comments: [Comment], in doc: WordDocument, contextChars: Int) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+        let entries = comments.map { comment -> String in
+            let context = commentContext(for: comment, in: doc, contextChars: contextChars)
+            let fields = [
+                "\"id\":\(comment.id)",
+                "\"author\":\"\(Self.jsonEscape(comment.author))\"",
+                "\"date\":\"\(Self.jsonEscape(dateFormatter.string(from: comment.date)))\"",
+                "\"text\":\"\(Self.jsonEscape(comment.text))\"",
+                "\"paragraph_index\":\(comment.paragraphIndex)",
+                "\"resolved\":\(comment.done)",
+                "\"anchored_run_text\":\(jsonOptional(context.anchoredRunText))",
+                "\"context_before\":\(jsonOptional(context.contextBefore))",
+                "\"context_after\":\(jsonOptional(context.contextAfter))",
+                "\"flattened_text\":\(jsonOptional(context.flattenedText))"
+            ]
+            return "{\(fields.joined(separator: ","))}"
+        }
+
+        return "[\(entries.joined(separator: ","))]"
+    }
+
+    private func jsonOptional(_ value: String?) -> String {
+        guard let value = value else { return "null" }
+        return "\"\(Self.jsonEscape(value))\""
+    }
+
+    private func commentContext(for comment: Comment, in doc: WordDocument, contextChars: Int) -> CommentContext {
+        let paragraphs = doc.getParagraphs()
+        guard comment.paragraphIndex >= 0, comment.paragraphIndex < paragraphs.count else {
+            return CommentContext(anchoredRunText: nil, contextBefore: nil, contextAfter: nil, flattenedText: nil)
+        }
+
+        let para = paragraphs[comment.paragraphIndex]
+        let flattened = para.flattenedDisplayText()
+        guard !flattened.isEmpty else {
+            return CommentContext(anchoredRunText: nil, contextBefore: nil, contextAfter: nil, flattenedText: flattened)
+        }
+
+        if let positional = positionalCommentContext(for: comment.id, in: para, fallback: flattened, contextChars: contextChars) {
+            return positional
+        }
+
+        return CommentContext(
+            anchoredRunText: flattened,
+            contextBefore: "",
+            contextAfter: "",
+            flattenedText: flattened
+        )
+    }
+
+    private func positionalCommentContext(
+        for commentId: Int,
+        in para: Paragraph,
+        fallback: String,
+        contextChars: Int
+    ) -> CommentContext? {
+        guard let start = para.commentRangeMarkers.first(where: { $0.id == commentId && $0.kind == .start })?.position,
+              let end = para.commentRangeMarkers.first(where: { $0.id == commentId && $0.kind == .end })?.position,
+              start < end else {
+            return nil
+        }
+
+        let segments = para.runs
+            .filter { !$0.text.isEmpty }
+            .map { (position: $0.position ?? 0, text: $0.text) }
+            .sorted { lhs, rhs in lhs.position < rhs.position }
+
+        guard !segments.isEmpty else { return nil }
+
+        let before = segments.filter { $0.position <= start }.map(\.text).joined()
+        let anchor = segments.filter { $0.position > start && $0.position < end }.map(\.text).joined()
+        let after = segments.filter { $0.position >= end }.map(\.text).joined()
+        guard !anchor.isEmpty else { return nil }
+
+        return CommentContext(
+            anchoredRunText: anchor,
+            contextBefore: suffix(before, maxLength: contextChars),
+            contextAfter: prefix(after, maxLength: contextChars),
+            flattenedText: fallback
+        )
+    }
+
+    private func prefix(_ text: String, maxLength: Int) -> String {
+        guard maxLength >= 0, text.count > maxLength else { return text }
+        return String(text.prefix(maxLength))
+    }
+
+    private func suffix(_ text: String, maxLength: Int) -> String {
+        guard maxLength >= 0, text.count > maxLength else { return text }
+        return String(text.suffix(maxLength))
     }
 
     private func enableTrackChanges(args: [String: Value]) async throws -> String {
@@ -9290,21 +9542,28 @@ actor WordMCPServer {
         guard var doc = openDocuments[docId] else {
             throw WordError.documentNotFound(docId)
         }
-        guard let commentId = args["comment_id"]?.intValue else {
+        guard let commentId = args["comment_id"]?.intValue ?? args["parent_comment_id"]?.intValue else {
             throw WordError.missingParameter("comment_id")
         }
-        guard let replyText = args["reply_text"]?.stringValue else {
-            throw WordError.missingParameter("reply_text")
+        guard let replyText = try resolveCommentReplyText(args: args) else {
+            throw WordError.missingParameter("reply_text or text or template")
         }
         let author = args["author"]?.stringValue ?? "User"
+        let shouldResolve = args["resolve"]?.boolValue ?? false
 
         // 使用 CommentsCollection.addReply 方法
         guard let reply = doc.comments.addReply(to: commentId, author: author, text: replyText) else {
             throw WordError.invalidParameter("comment_id", "Comment with ID \(commentId) not found")
         }
+        if shouldResolve {
+            doc.comments.markAsDone(commentId, done: true)
+        }
+        doc.markPartDirty("word/comments.xml")
+        doc.markPartDirty("word/commentsExtended.xml")
 
         try await storeDocument(doc, for: docId)
-        return "Added reply to comment \(commentId) by \(author) (reply ID: \(reply.id))"
+        let resolvedSuffix = shouldResolve ? " and resolved comment \(commentId)" : ""
+        return "Added reply to comment \(commentId) by \(author) (reply ID: \(reply.id))\(resolvedSuffix)"
     }
 
     private func resolveComment(args: [String: Value]) async throws -> String {
@@ -9321,9 +9580,80 @@ actor WordMCPServer {
 
         // 使用 CommentsCollection.markAsDone 方法
         doc.comments.markAsDone(commentId, done: resolved)
+        doc.markPartDirty("word/commentsExtended.xml")
         try await storeDocument(doc, for: docId)
 
         return "Comment \(commentId) \(resolved ? "resolved" : "reopened")"
+    }
+
+    private func bulkResolveComments(args: [String: Value]) async throws -> String {
+        guard let docId = args["doc_id"]?.stringValue else {
+            throw WordError.missingParameter("doc_id")
+        }
+        guard var doc = openDocuments[docId] else {
+            throw WordError.documentNotFound(docId)
+        }
+        guard let ids = args["comment_ids"]?.arrayValue else {
+            throw WordError.missingParameter("comment_ids")
+        }
+
+        var resolvedCount = 0
+        var failed: [String] = []
+        for value in ids {
+            guard let id = value.intValue else {
+                failed.append("{\"comment_id\":null,\"error\":\"invalid_id\"}")
+                continue
+            }
+            guard doc.comments.comments.contains(where: { $0.id == id }) else {
+                failed.append("{\"comment_id\":\(id),\"error\":\"not_found\"}")
+                continue
+            }
+            doc.comments.markAsDone(id, done: true)
+            resolvedCount += 1
+        }
+
+        if resolvedCount > 0 {
+            doc.markPartDirty("word/commentsExtended.xml")
+            try await storeDocument(doc, for: docId)
+        }
+
+        return "{\"resolved\":\(resolvedCount),\"failed\":[\(failed.joined(separator: ","))]}"
+    }
+
+    private func resolveCommentReplyText(args: [String: Value]) throws -> String? {
+        if let text = args["reply_text"]?.stringValue ?? args["text"]?.stringValue {
+            return text
+        }
+        guard let templateName = args["template"]?.stringValue else {
+            return nil
+        }
+        let templates = [
+            "fix_done": "Fixed in ${commit_sha} (Refs #${issue_number})",
+            "noted": "Noted.",
+            "wontfix": "Won't fix: ${reason}",
+            "more_info_needed": "Need more information: ${question}"
+        ]
+        guard var rendered = templates[templateName] else {
+            throw WordError.invalidParameter("template", "Unknown template '\(templateName)'")
+        }
+
+        let vars = args["vars"]?.objectValue ?? [:]
+        for (key, value) in vars {
+            if let str = templateVariableString(value) {
+                rendered = rendered.replacingOccurrences(of: "${\(key)}", with: str)
+            }
+        }
+        if rendered.range(of: #"\$\{[^}]+\}"#, options: .regularExpression) != nil {
+            throw WordError.invalidParameter("vars", "Missing template variable for '\(templateName)'")
+        }
+        return rendered
+    }
+
+    private func templateVariableString(_ value: Value) -> String? {
+        if let str = value.stringValue { return str }
+        if let int = value.intValue { return String(int) }
+        if let bool = value.boolValue { return String(bool) }
+        return nil
     }
 
     // MARK: - 8.2 Floating Images
@@ -10346,6 +10676,133 @@ actor WordMCPServer {
             output += "- \(result.location), position \(result.startPosition): \"\(result.text)\"\n"
         }
         return output
+    }
+
+    private func findInlineMathGaps(args: [String: Value]) async throws -> String {
+        let (doc, _) = try await resolveDocument(args: args)
+        let minGapChars = max(1, args["min_gap_chars"]?.intValue ?? 2)
+        let contextChars = max(0, args["context_chars"]?.intValue ?? 30)
+        let excludeTableCaptions = args["exclude_table_captions"]?.boolValue ?? true
+
+        struct Gap {
+            let paragraphIndex: Int
+            let location: String
+            let gapPosition: Int
+            let gapLength: Int
+            let contextBefore: String
+            let contextAfter: String
+            let flattenedText: String
+        }
+
+        var gaps: [Gap] = []
+
+        func isWhitespace(_ char: Character) -> Bool {
+            char.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
+        }
+
+        func scanParagraph(_ para: Paragraph, paragraphIndex: Int?, location: String) {
+            let text = para.flattenedDisplayText()
+            guard !text.isEmpty else { return }
+            if excludeTableCaptions && isLikelyTableCaption(text) { return }
+
+            let chars = Array(text)
+            var i = 0
+            while i < chars.count {
+                guard isWhitespace(chars[i]) else {
+                    i += 1
+                    continue
+                }
+
+                let start = i
+                while i < chars.count, isWhitespace(chars[i]) {
+                    i += 1
+                }
+                let length = i - start
+                let hasNonWhitespaceBefore = start > 0 && !isWhitespace(chars[start - 1])
+                let hasNonWhitespaceAfter = i < chars.count && !isWhitespace(chars[i])
+                guard length >= minGapChars, hasNonWhitespaceBefore, hasNonWhitespaceAfter else {
+                    continue
+                }
+
+                let beforeStart = max(0, start - contextChars)
+                let afterEnd = min(chars.count, i + contextChars)
+                gaps.append(Gap(
+                    paragraphIndex: paragraphIndex ?? -1,
+                    location: location,
+                    gapPosition: start,
+                    gapLength: length,
+                    contextBefore: String(chars[beforeStart..<start]),
+                    contextAfter: String(chars[i..<afterEnd]),
+                    flattenedText: text
+                ))
+            }
+        }
+
+        var paragraphCounter = 0
+        var tableCounter = 0
+
+        func scanTable(_ table: Table, tablePath: String) {
+            for (rowIndex, row) in table.rows.enumerated() {
+                for (cellIndex, cell) in row.cells.enumerated() {
+                    for (paraIndex, para) in cell.paragraphs.enumerated() {
+                        scanParagraph(
+                            para,
+                            paragraphIndex: nil,
+                            location: "\(tablePath).row[\(rowIndex)].col[\(cellIndex)].paragraph[\(paraIndex)]"
+                        )
+                    }
+                    for (nestedIndex, nested) in cell.nestedTables.enumerated() {
+                        scanTable(
+                            nested,
+                            tablePath: "\(tablePath).row[\(rowIndex)].col[\(cellIndex)].nested_table[\(nestedIndex)]"
+                        )
+                    }
+                }
+            }
+        }
+
+        func walk(_ children: [BodyChild]) {
+            for child in children {
+                switch child {
+                case .paragraph(let para):
+                    scanParagraph(para, paragraphIndex: paragraphCounter, location: "paragraph[\(paragraphCounter)]")
+                    paragraphCounter += 1
+                case .table(let table):
+                    scanTable(table, tablePath: "table[\(tableCounter)]")
+                    tableCounter += 1
+                case .contentControl(_, children: let inner):
+                    walk(inner)
+                case .bookmarkMarker, .rawBlockElement:
+                    continue
+                }
+            }
+        }
+
+        walk(doc.body.children)
+
+        let entries = gaps.map { gap in
+            [
+                "\"paragraph_index\":\(gap.paragraphIndex)",
+                "\"location\":\"\(Self.jsonEscape(gap.location))\"",
+                "\"gap_position\":\(gap.gapPosition)",
+                "\"gap_length\":\(gap.gapLength)",
+                "\"context_before\":\"\(Self.jsonEscape(gap.contextBefore))\"",
+                "\"context_after\":\"\(Self.jsonEscape(gap.contextAfter))\"",
+                "\"flattened_text\":\"\(Self.jsonEscape(gap.flattenedText))\""
+            ].joined(separator: ",")
+        }.map { "{\($0)}" }
+
+        return "[\(entries.joined(separator: ","))]"
+    }
+
+    private func isLikelyTableCaption(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        return lower.hasPrefix("table ")
+            || lower.hasPrefix("table\t")
+            || trimmed.hasPrefix("表 ")
+            || trimmed.hasPrefix("表\t")
+            || trimmed.hasPrefix("表格")
     }
 
     // 9.4 list_hyperlinks - 列出所有超連結

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -10680,8 +10680,12 @@ actor WordMCPServer {
 
     private func findInlineMathGaps(args: [String: Value]) async throws -> String {
         let (doc, _) = try await resolveDocument(args: args)
-        let minGapChars = max(1, args["min_gap_chars"]?.intValue ?? 2)
-        let contextChars = max(0, args["context_chars"]?.intValue ?? 30)
+        // Upper-bound clamps prevent caller-triggered Int overflow trap in
+        // `i + contextChars` (issue #130). 4096 chars is far more context than
+        // any human reads at a glance; min_gap_chars 1024 covers the longest
+        // plausible accidental whitespace run (a fully-blanked paragraph).
+        let minGapChars = min(max(1, args["min_gap_chars"]?.intValue ?? 2), 1024)
+        let contextChars = min(max(0, args["context_chars"]?.intValue ?? 30), 4096)
         let excludeTableCaptions = args["exclude_table_captions"]?.boolValue ?? true
 
         struct Gap {

--- a/Tests/CheWordMCPTests/CommentReviewWorkflowToolsTests.swift
+++ b/Tests/CheWordMCPTests/CommentReviewWorkflowToolsTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import MCP
+import OOXMLSwift
+@testable import CheWordMCP
+
+final class CommentReviewWorkflowToolsTests: XCTestCase {
+
+    func testListCommentsCanIncludeAnchorContextPreview() async throws {
+        let url = try writeCommentFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        let opened = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("comments")]
+        )
+        XCTAssertFalse(textOf(opened).contains("Error:"), textOf(opened))
+
+        let listed = await server.invokeToolForTesting(
+            name: "list_comments",
+            arguments: [
+                "doc_id": .string("comments"),
+                "include_context": .bool(true),
+                "context_chars": .int(12)
+            ]
+        )
+        let text = textOf(listed)
+        XCTAssertTrue(text.contains(#""id":1"#), text)
+        XCTAssertTrue(text.contains(#""anchored_run_text":"target phrase""#), text)
+        XCTAssertTrue(text.contains(#""context_before":"Before ""#), text)
+        XCTAssertTrue(text.contains(#""context_after":" after""#), text)
+    }
+
+    func testReplyTemplateCanResolveAndFindUnresolvedFiltersDoneComments() async throws {
+        let url = try writeCommentFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("workflow")]
+        )
+
+        let reply = await server.invokeToolForTesting(
+            name: "add_comment_reply",
+            arguments: [
+                "doc_id": .string("workflow"),
+                "comment_id": .int(1),
+                "template": .string("fix_done"),
+                "vars": .object([
+                    "commit_sha": .string("abc1234"),
+                    "issue_number": .int(88)
+                ]),
+                "resolve": .bool(true),
+                "author": .string("Codex")
+            ]
+        )
+        let replyText = textOf(reply)
+        XCTAssertTrue(replyText.contains("Added reply to comment 1"), replyText)
+        XCTAssertTrue(replyText.contains("resolved"), replyText)
+
+        let thread = await server.invokeToolForTesting(
+            name: "get_comment_thread",
+            arguments: ["doc_id": .string("workflow"), "root_comment_id": .int(1)]
+        )
+        XCTAssertTrue(textOf(thread).contains("Fixed in abc1234 (Refs #88)"), textOf(thread))
+
+        let unresolved = await server.invokeToolForTesting(
+            name: "find_unresolved_comments",
+            arguments: ["doc_id": .string("workflow")]
+        )
+        let unresolvedText = textOf(unresolved)
+        XCTAssertFalse(unresolvedText.contains(#""id":1"#), unresolvedText)
+        XCTAssertTrue(unresolvedText.contains(#""id":2"#), unresolvedText)
+    }
+
+    func testBulkResolveReportsPartialFailures() async throws {
+        let url = try writeCommentFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("bulk")]
+        )
+
+        let result = await server.invokeToolForTesting(
+            name: "bulk_resolve_comments",
+            arguments: [
+                "doc_id": .string("bulk"),
+                "comment_ids": .array([.int(1), .int(999)])
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertTrue(text.contains(#""resolved":1"#), text)
+        XCTAssertTrue(text.contains(#""comment_id":999"#), text)
+        XCTAssertTrue(text.contains(#""error":"not_found""#), text)
+    }
+
+    func testFindInlineMathGapsScansBodyAndTableCells() async throws {
+        let url = try writeGapFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("gaps")]
+        )
+
+        let result = await server.invokeToolForTesting(
+            name: "find_inline_math_gaps",
+            arguments: [
+                "doc_id": .string("gaps"),
+                "min_gap_chars": .int(2),
+                "context_chars": .int(12),
+                "exclude_table_captions": .bool(true)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertTrue(text.contains(#""paragraph_index":0"#), text)
+        XCTAssertTrue(text.contains(#""context_before":"若""#), text)
+        XCTAssertTrue(text.contains(#""context_after":"顯著為正""#), text)
+        XCTAssertTrue(text.contains(#""location":"table[0].row[0].col[0].paragraph[0]""#), text)
+        XCTAssertFalse(text.contains("caption"), text)
+    }
+
+    // MARK: - Helpers
+
+    private func writeCommentFixture() throws -> URL {
+        var doc = WordDocument()
+
+        var commented = Paragraph(runs: [
+            positionedRun("Before ", 1),
+            positionedRun("target phrase", 3),
+            positionedRun(" after", 5)
+        ])
+        commented.commentRangeMarkers = [
+            CommentRangeMarker(kind: .start, id: 1, position: 2),
+            CommentRangeMarker(kind: .end, id: 1, position: 4)
+        ]
+        doc.body.children.append(.paragraph(commented))
+        doc.body.children.append(.paragraph(Paragraph(text: "Second paragraph")))
+
+        doc.comments.addComment(Comment(id: 1, author: "Advisor", text: "Please fix", paragraphIndex: 0))
+        doc.comments.addComment(Comment(id: 2, author: "Advisor", text: "Still open", paragraphIndex: 1))
+
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("comment_workflow_\(UUID().uuidString).docx")
+        try DocxWriter.write(doc, to: url)
+        return url
+    }
+
+    private func writeGapFixture() throws -> URL {
+        var doc = WordDocument()
+        doc.body.children.append(.paragraph(Paragraph(text: "若  顯著為正")))
+        doc.body.children.append(.paragraph(Paragraph(text: "表 1 caption  gap")))
+        let table = Table(rows: [
+            TableRow(cells: [
+                TableCell(paragraphs: [Paragraph(text: "cell  gap")])
+            ])
+        ])
+        doc.body.children.append(.table(table))
+
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("math_gaps_\(UUID().uuidString).docx")
+        try DocxWriter.write(doc, to: url)
+        return url
+    }
+
+    private func positionedRun(_ text: String, _ position: Int) -> Run {
+        var run = Run(text: text)
+        run.position = position
+        return run
+    }
+
+    private func textOf(_ r: CallTool.Result) -> String {
+        r.content.compactMap { item -> String? in
+            if case let .text(t, _, _) = item { return t } else { return nil }
+        }.joined(separator: "\n")
+    }
+}

--- a/Tests/CheWordMCPTests/CommentReviewWorkflowToolsTests.swift
+++ b/Tests/CheWordMCPTests/CommentReviewWorkflowToolsTests.swift
@@ -124,6 +124,70 @@ final class CommentReviewWorkflowToolsTests: XCTestCase {
         XCTAssertFalse(text.contains("caption"), text)
     }
 
+    // MARK: - Issue #130 — Int.max overflow regression
+
+    func testFindInlineMathGapsClampsHugeContextChars() async throws {
+        // Pre-fix: `i + contextChars` with contextChars = Int.max trapped on
+        // arithmetic overflow → MCP server actor crashed. Post-fix clamps
+        // contextChars to 4096 before the addition. Verify the call returns
+        // a normal JSON response without crashing.
+        let url = try writeGapFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("gap_intmax")]
+        )
+
+        let result = await server.invokeToolForTesting(
+            name: "find_inline_math_gaps",
+            arguments: [
+                "doc_id": .string("gap_intmax"),
+                "context_chars": .int(.max)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertFalse(
+            text.lowercased().contains("error"),
+            "expected clamped context_chars to succeed without server-side error; got: \(text)"
+        )
+        // Sanity: response should still surface the body-level gap fixture.
+        XCTAssertTrue(
+            text.contains(#""paragraph_index":0"#),
+            "expected normal gap output post-clamp; got: \(text)"
+        )
+    }
+
+    func testFindInlineMathGapsClampsHugeMinGapChars() async throws {
+        // min_gap_chars: Int.max would never match (no real paragraph has
+        // INT_MAX whitespace chars), but pre-fix it still consumed the
+        // gap-scan inner loop's `length >= minGapChars` comparison as a giant
+        // unsigned-equivalent miss path. Post-fix clamps to 1024, covering
+        // any plausible accidental whitespace run.
+        let url = try writeGapFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(url.path), "doc_id": .string("gap_min_intmax")]
+        )
+
+        let result = await server.invokeToolForTesting(
+            name: "find_inline_math_gaps",
+            arguments: [
+                "doc_id": .string("gap_min_intmax"),
+                "min_gap_chars": .int(.max)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertFalse(
+            text.lowercased().contains("error"),
+            "expected clamped min_gap_chars to succeed without error; got: \(text)"
+        )
+    }
+
     // MARK: - Helpers
 
     private func writeCommentFixture() throws -> URL {


### PR DESCRIPTION
## Summary
- Add `list_comments(include_context:true)` JSON context output for anchored comment previews.
- Add `add_comment_reply`, `bulk_resolve_comments`, and `find_unresolved_comments` review workflow helpers.
- Add `find_inline_math_gaps` Phase 1 whitespace-gap scanner for suspected missing inline math.
- Add regression tests covering #88, #95, and #96 workflows.

## Tests
- `swift test --filter CommentReviewWorkflowToolsTests`
- `swift test`

Refs #88, #95, #96
