### PR TITLE
Document paragraph index conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ curl -o .claude/skills/che-word-mcp/SKILL.md \
 
 ## Available Tools (233 Total)
 
+### Paragraph Index Conventions
+
+`paragraph_index` / `index` are historical parameter names and do not always
+count the same OOXML surface. Insert tools generally use a `body.children`
+insertion index; direct paragraph mutation tools generally use a top-level
+paragraph ordinal; readback tools such as `get_paragraphs` use their own
+returned paragraph order. See [docs/paragraph-index-conventions.md](docs/paragraph-index-conventions.md)
+before reusing an index across tools.
+
 ### Document Management (6 tools)
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -241,11 +241,14 @@ curl -o .claude/skills/che-word-mcp/SKILL.md \
 ### Paragraph Index Conventions
 
 `paragraph_index` / `index` are historical parameter names and do not always
-count the same OOXML surface. Insert tools generally use a `body.children`
-insertion index; direct paragraph mutation tools generally use a top-level
-paragraph ordinal; readback tools such as `get_paragraphs` use their own
-returned paragraph order. See [docs/paragraph-index-conventions.md](docs/paragraph-index-conventions.md)
-before reusing an index across tools.
+count the same OOXML surface. **Different insert / mutate / readback tools
+use different conventions** — there is no universal default to assume.
+Three coordinate systems coexist:
+`body.children` insertion index (used by some inserts), top-level paragraph
+ordinal (used by most mutate operations and inline equation insertion),
+and `get_paragraphs` readback order (for inspection). See
+[docs/paragraph-index-conventions.md](docs/paragraph-index-conventions.md)
+for the per-tool inventory before reusing an index across tools.
 
 ### Document Management (6 tools)
 

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -764,7 +764,7 @@ actor WordMCPServer {
             ),
             Tool(
                 name: "get_paragraphs",
-                description: "取得所有段落（含格式資訊）（支援 Direct Mode）",
+                description: "取得所有段落（含格式資訊）（支援 Direct Mode）。回傳順序是 get_paragraphs readback index：top-level paragraphs + block-level SDT 內段落；不含 table-cell paragraphs。不要直接當作 body.children 插入索引使用。",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -781,7 +781,7 @@ actor WordMCPServer {
             ),
             Tool(
                 name: "insert_paragraph",
-                description: "插入新段落（需先 open_document）。v3.15.1+ 接受 after_text / before_text / text_instance / into_table_cell / after_image_id anchor（與 insert_image_from_path 對齊）；anchor 與 index 擇一，不傳則加到最後。v3.16.0+ 同時傳多個 anchor 會 return 「Error: insert_paragraph: received conflicting anchors: ...」（先前版本是 silent priority winner）。",
+                description: "插入新段落（需先 open_document）。index 是 body.children 插入索引（top-level OOXML body child；計入 tables / block-level SDTs / bookmark markers / raw blocks）。v3.15.1+ 接受 after_text / before_text / text_instance / into_table_cell / after_image_id anchor（與 insert_image_from_path 對齊）；anchor 與 index 擇一，不傳則加到最後。v3.16.0+ 同時傳多個 anchor 會 return 「Error: insert_paragraph: received conflicting anchors: ...」（先前版本是 silent priority winner）。",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -795,7 +795,7 @@ actor WordMCPServer {
                         ]),
                         "index": .object([
                             "type": .string("integer"),
-                            "description": .string("插入位置（body 層級索引，從 0 開始）。anchor 擇一，不傳則加到最後")
+                            "description": .string("body.children 插入索引（從 0 開始；計入 tables / block-level SDTs / bookmark markers / raw blocks）。不是 get_paragraphs 的 paragraph readback index。anchor 擇一，不傳則加到最後")
                         ]),
                         "style": .object([
                             "type": .string("string"),
@@ -837,7 +837,7 @@ actor WordMCPServer {
                         ]),
                         "index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "text": .object([
                             "type": .string("string"),
@@ -859,7 +859,7 @@ actor WordMCPServer {
                         ]),
                         "index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ])
                     ]),
                     "required": .array([.string("doc_id"), .string("index")])
@@ -939,7 +939,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "bold": .object([
                             "type": .string("boolean"),
@@ -997,7 +997,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "alignment": .object([
                             "type": .string("string"),
@@ -1043,7 +1043,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "style": .object([
                             "type": .string("string"),
@@ -2126,7 +2126,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("要附加註解的段落索引")
+                            "description": .string("要附加註解的 top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`）")
                         ])
                     ]),
                     "required": .array([.string("doc_id"), .string("text"), .string("author"), .string("paragraph_index")])
@@ -2335,7 +2335,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "text": .object([
                             "type": .string("string"),
@@ -2375,7 +2375,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "text": .object([
                             "type": .string("string"),
@@ -2447,7 +2447,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "name": .object([
                             "type": .string("string"),
@@ -2473,7 +2473,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "name": .object([
                             "type": .string("string"),
@@ -2499,7 +2499,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "name": .object([
                             "type": .string("string"),
@@ -2583,7 +2583,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "border_type": .object([
                             "type": .string("string"),
@@ -2613,7 +2613,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "fill": .object([
                             "type": .string("string"),
@@ -2635,7 +2635,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`，不計 tables / block-level SDTs）")
                         ]),
                         "spacing": .object([
                             "type": .string("integer"),
@@ -3823,7 +3823,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("get_paragraphs readback index（從 0 開始；top-level paragraphs + block-level SDT 內段落，不含 table-cell paragraphs）")
                         ])
                     ]),
                     "required": .array([.string("doc_id"), .string("paragraph_index")])
@@ -3843,7 +3843,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("指定段落索引（可選，不指定則取得全部）")
+                            "description": .string("指定 get_paragraphs readback index（可選；不指定則取得全部）")
                         ])
                     ]),
                     "required": .array([.string("doc_id")])
@@ -4859,7 +4859,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("插入位置段落索引（五 anchor 擇一；可搭配 position）")
+                            "description": .string("body.children 插入索引（從 0 開始；計入 tables / block-level SDTs / bookmark markers / raw blocks）。五 anchor 擇一；可搭配 position")
                         ]),
                         "after_image_id": .object([
                             "type": .string("string"),

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -2657,7 +2657,7 @@ actor WordMCPServer {
                         ]),
                         "paragraph_index": .object([
                             "type": .string("integer"),
-                            "description": .string("段落索引（從 0 開始）")
+                            "description": .string("Top-level paragraph ordinal（從 0 開始；不計入 tables / SDTs / bookmarkMarker / rawBlockElement）。詳見 docs/paragraph-index-conventions.md。")
                         ]),
                         "effect": .object([
                             "type": .string("string"),

--- a/Tests/CheWordMCPTests/Issue97ParagraphIndexConventionTests.swift
+++ b/Tests/CheWordMCPTests/Issue97ParagraphIndexConventionTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import OOXMLSwift
+@testable import CheWordMCP
+
+/// PsychQuant/che-word-mcp#97 — pin the current paragraph-index convention
+/// split without changing public API behavior.
+final class Issue97ParagraphIndexConventionTests: XCTestCase {
+
+    func testCrossFamilyFixturePinsCurrentIndexSemantics() throws {
+        let doc = conventionFixture()
+
+        XCTAssertEqual(doc.body.children.count, 4, "fixture must include paragraph + table + block-level SDT + paragraph")
+        XCTAssertEqual(
+            doc.getParagraphs().map { $0.getText() },
+            ["top-0", "sdt-inner", "top-1"],
+            "getParagraphs readback index descends into block-level SDTs but skips table-cell paragraphs"
+        )
+
+        var insertDoc = doc
+        insertDoc.insertParagraph(Paragraph(runs: [Run(text: "inserted-before-table")]), at: 1)
+        XCTAssertEqual(textOfBodyChild(insertDoc.body.children[1]), "inserted-before-table")
+        XCTAssertTrue(isTable(insertDoc.body.children[2]), "body.children insertion index 1 must insert before the table body child")
+
+        var mutateDoc = doc
+        var bold = RunProperties()
+        bold.bold = true
+        try mutateDoc.formatParagraph(at: 1, with: bold)
+
+        guard case .paragraph(let topOne) = mutateDoc.body.children[3] else {
+            XCTFail("fixture body child 3 should remain the second top-level paragraph")
+            return
+        }
+        XCTAssertTrue(topOne.runs.first?.properties.bold ?? false, "top-level paragraph ordinal 1 targets the second direct body paragraph")
+
+        guard case .contentControl(_, let children) = mutateDoc.body.children[2],
+              case .paragraph(let sdtPara) = children.first else {
+            XCTFail("fixture body child 2 should be a block-level SDT containing one paragraph")
+            return
+        }
+        XCTAssertFalse(
+            sdtPara.runs.first?.properties.bold ?? false,
+            "top-level paragraph ordinal must not target the block-level SDT child paragraph"
+        )
+    }
+
+    func testParagraphIndexConventionDocsInventoryExists() throws {
+        let docs = try String(contentsOf: repoRoot().appendingPathComponent("docs/paragraph-index-conventions.md"), encoding: .utf8)
+
+        XCTAssertTrue(docs.contains("`body.children` insertion index"))
+        XCTAssertTrue(docs.contains("Top-level paragraph ordinal"))
+        XCTAssertTrue(docs.contains("`get_paragraphs` readback index"))
+        XCTAssertTrue(docs.contains("`insert_paragraph.index`"))
+        XCTAssertTrue(docs.contains("`insert_caption.paragraph_index`"))
+        XCTAssertTrue(docs.contains("`format_text.paragraph_index`, `set_paragraph_format.paragraph_index`, `apply_style.paragraph_index`"))
+        XCTAssertTrue(docs.contains("`set_paragraph_border.paragraph_index`, `set_paragraph_shading.paragraph_index`, `set_character_spacing.paragraph_index`, `set_text_effect.paragraph_index`"))
+        XCTAssertTrue(docs.contains("`get_paragraph_runs.paragraph_index`, `get_text_with_formatting.paragraph_index`"))
+        XCTAssertTrue(docs.contains("Public API renaming or typed wrapper indices would be a breaking change"))
+    }
+
+    func testRepresentativeSchemaDescriptionsNameIndexFamilies() throws {
+        let source = try String(contentsOf: repoRoot().appendingPathComponent("Sources/CheWordMCP/Server.swift"), encoding: .utf8)
+
+        XCTAssertTrue(source.contains("get_paragraphs readback index：top-level paragraphs + block-level SDT 內段落"))
+        XCTAssertTrue(source.contains("index 是 body.children 插入索引"))
+        XCTAssertTrue(source.contains("不是 get_paragraphs 的 paragraph readback index"))
+        XCTAssertTrue(source.contains("top-level paragraph ordinal（從 0 開始；只計直接位於 body.children 的 `.paragraph`"))
+        XCTAssertTrue(source.contains("body.children 插入索引（從 0 開始；計入 tables / block-level SDTs / bookmark markers / raw blocks）。五 anchor 擇一"))
+    }
+
+    func testReadmeLinksConventionGuide() throws {
+        let readme = try String(contentsOf: repoRoot().appendingPathComponent("README.md"), encoding: .utf8)
+        XCTAssertTrue(readme.contains("### Paragraph Index Conventions"))
+        XCTAssertTrue(readme.contains("[docs/paragraph-index-conventions.md](docs/paragraph-index-conventions.md)"))
+    }
+
+    private func conventionFixture() -> WordDocument {
+        var doc = WordDocument()
+        doc.body.children.append(.paragraph(Paragraph(runs: [Run(text: "top-0")])))
+        doc.body.children.append(.table(Table(rows: [
+            TableRow(cells: [TableCell(paragraphs: [Paragraph(runs: [Run(text: "table-cell")])])])
+        ])))
+        let sdt = StructuredDocumentTag(
+            id: 9701,
+            tag: "issue97_wrapper",
+            alias: "Issue 97 Wrapper",
+            type: .richText
+        )
+        let control = ContentControl(sdt: sdt, content: "")
+        doc.body.children.append(.contentControl(control, children: [
+            .paragraph(Paragraph(runs: [Run(text: "sdt-inner")]))
+        ]))
+        doc.body.children.append(.paragraph(Paragraph(runs: [Run(text: "top-1")])))
+        return doc
+    }
+
+    private func textOfBodyChild(_ child: BodyChild) -> String {
+        if case .paragraph(let para) = child { return para.getText() }
+        return ""
+    }
+
+    private func isTable(_ child: BodyChild) -> Bool {
+        if case .table = child { return true }
+        return false
+    }
+
+    private func repoRoot() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.pathComponents.count > 1 {
+            url = url.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("Package.swift").path) {
+                return url
+            }
+        }
+        return URL(fileURLWithPath: "/dev/null")
+    }
+}

--- a/docs/paragraph-index-conventions.md
+++ b/docs/paragraph-index-conventions.md
@@ -1,5 +1,18 @@
 # Paragraph Index Conventions
 
+> **Status — current behavior, canonical pick pending.**
+> This document describes the *current* `paragraph_index` conventions across
+> MCP tools, which differ between insert / mutate / readback families. The
+> canonical convention pick (so callers can rely on one universal index
+> family) is tracked in
+> [PsychQuant/ooxml-swift#10](https://github.com/PsychQuant/ooxml-swift/issues/10)
+> and a future macdoc Spectra change. Until that lands, callers should
+> consult the per-tool inventory below rather than assume one universal
+> index family. Schema descriptions in `Server.swift` are being updated
+> incrementally — if a tool's schema text says only `段落索引（從 0 開始）`
+> without specifying which family, treat that as stale and look it up here.
+> Schema-audit follow-up: [#138](https://github.com/PsychQuant/che-word-mcp/issues/138).
+
 `paragraph_index` and `index` are historical names in this project. They do
 not always count the same thing, because inserting a new OOXML block and
 mutating an existing paragraph use different coordinate systems.

--- a/docs/paragraph-index-conventions.md
+++ b/docs/paragraph-index-conventions.md
@@ -1,0 +1,55 @@
+# Paragraph Index Conventions
+
+`paragraph_index` and `index` are historical names in this project. They do
+not always count the same thing, because inserting a new OOXML block and
+mutating an existing paragraph use different coordinate systems.
+
+## Index Families
+
+| Family | Counts | Skips | Typical use |
+| --- | --- | --- | --- |
+| `body.children` insertion index | Every top-level child under `w:body`: paragraphs, tables, block-level SDTs, bookmark markers, raw block elements | Nothing at the top level | Insert a new top-level block before/after a body child |
+| Top-level paragraph ordinal | Top-level `.paragraph` body children only | Tables, block-level SDTs, bookmark markers, raw block elements | Mutate an existing direct body paragraph |
+| `get_paragraphs` readback index | Top-level paragraphs plus paragraphs inside block-level SDTs | Table-cell paragraphs | Read or inspect paragraphs returned by `get_paragraphs` |
+
+The same integer is not portable across these families. For example, in a
+document whose body is:
+
+1. Top-level paragraph
+2. Table
+3. Block-level SDT containing one paragraph
+4. Top-level paragraph
+
+`insert_paragraph(index: 1)` inserts before the table, because index `1` is a
+`body.children` insertion point. `format_text(paragraph_index: 1)` targets the
+second top-level paragraph, because formatting uses top-level paragraph
+ordinal. `get_paragraphs()[1]` returns the paragraph inside the block-level
+SDT, because `get_paragraphs` descends into block-level SDTs but not tables.
+
+## Tool Inventory
+
+| Tool / parameter | Family | Notes |
+| --- | --- | --- |
+| `insert_paragraph.index` | `body.children` insertion index | `index == body.children.count` appends at end. |
+| `insert_caption.paragraph_index` | `body.children` insertion index | Used with `position` to insert above or below a body child. |
+| `insert_equation.paragraph_index`, `display_mode=true` | `body.children` insertion index | Display equations are inserted as a new top-level paragraph. |
+| `insert_equation.paragraph_index`, `display_mode=false` | Top-level paragraph ordinal | Inline equations append an OMML run to an existing direct body paragraph. |
+| `update_paragraph.index`, `delete_paragraph.index` | Top-level paragraph ordinal | Historical `index` name; not a `body.children` insertion point. |
+| `format_text.paragraph_index`, `set_paragraph_format.paragraph_index`, `apply_style.paragraph_index` | Top-level paragraph ordinal | Mutates direct body paragraphs. |
+| `set_paragraph_border.paragraph_index`, `set_paragraph_shading.paragraph_index`, `set_character_spacing.paragraph_index`, `set_text_effect.paragraph_index` | Top-level paragraph ordinal | Advanced paragraph formatting tools mutate direct body paragraphs. |
+| `insert_comment.paragraph_index` | Top-level paragraph ordinal | Comment anchors are attached to direct body paragraphs. |
+| `get_paragraph_runs.paragraph_index`, `get_text_with_formatting.paragraph_index` | `get_paragraphs` readback index | Use indices from `get_paragraphs`. |
+| `list_captions`, `list_equations`, `list_comments` returned `paragraph_index` | Tool-specific readback value | Treat returned values as readback metadata unless the target tool explicitly names the same family. |
+
+## Agent Guidance
+
+Prefer text/image/table anchors (`after_text`, `before_text`, `after_image_id`,
+`after_table_index`, `into_table_cell`) when available. They avoid cross-family
+index reuse and are more stable after edits.
+
+If a workflow must reuse an integer index, keep it within the same family. Do
+not feed a `get_paragraphs` array offset into an insert tool without first
+converting it to a `body.children` position.
+
+Public API renaming or typed wrapper indices would be a breaking change and
+should be handled through a separate SDD proposal.


### PR DESCRIPTION
## Summary

- Documents the three current index families: `body.children` insertion index, top-level paragraph ordinal, and `get_paragraphs` readback index.
- Updates representative MCP schema descriptions so agents do not reuse indices across incompatible tool families.
- Adds a regression fixture with a top-level paragraph, table, and block-level SDT to pin current behavior without changing public API semantics.

Refs #97

## Tests

- `swift test --filter Issue97ParagraphIndexConventionTests`
