### PR TITLE
Add page to paragraph estimate tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Swift-native MCP (Model Context Protocol) server for Microsoft Word document (
 - **Pure Swift Implementation**: No Node.js, Python, or external runtime required
 - **Direct OOXML Manipulation**: Works directly with XML, no Microsoft Word installation needed
 - **Single Binary**: Just one executable file
-- **233 MCP Tools**: Comprehensive document manipulation across documents, tables, hyperlinks, headers, sections, styles, numbering, content controls, comments, footnotes, equations, fields, and Track Changes
+- **234 MCP Tools**: Comprehensive document manipulation across documents, tables, hyperlinks, headers, sections, styles, numbering, content controls, comments, footnotes, equations, fields, and Track Changes
 - **Office.js OOXML Roadmap P0 = 100%**: All eight P0 sub-issues closed (umbrella [#43](https://github.com/PsychQuant/che-word-mcp/issues/43)). Surface coverage is now competitive with Office.js for the read/write side of every P0 capability.
 - **Round-trip silent corruption closed (v3.13.5, [#56](https://github.com/PsychQuant/che-word-mcp/issues/56))**: 5 sub-stack-completion rounds (R5 / R5-CONT / R5-CONT-2 / R5-CONT-3 / R5-CONT-4) closed 30 findings (16 P0 + 21 P1) across rounds 4-8 of 6-AI cross-verification. Bumps `ooxml-swift` to v0.19.5 (v0.19.4 held back per verify-gate). **No MCP source changes** — fix architecture lives entirely in `ooxml-swift`. Round 4 walker symmetry across headers/footers/footnotes/endnotes (`accept_revision` / `reject_revision` / `get_hyperlinks` / `replace_text` reach all parts). Round 5 per-container relationships round-trip (`update_hyperlink` URL sync targets owning part rels). Round 6 `delete_hyperlink` mirror + container `<w:tbl>` capture preserved. Round 7 `reject_revision` typed clearMarker (file/API state convergence). Round 8 `accept_revision` typed clearMarker (mirror) + matrix-pin asymmetry-guard removal + `Document.repairContainerFileNames` marks `document.xml.rels` + `[Content_Types].xml` dirty. Convergence: Devil's Advocate wrote 5 adversarial tests targeting the convergence-cycle pattern; all PASSED. See [closing summary](https://github.com/PsychQuant/che-word-mcp/issues/56#issuecomment-4322638865) and [v3.13.5 release notes](https://github.com/PsychQuant/che-word-mcp/releases/tag/v3.13.5).
 - **Programmatic Track Changes (v3.12.0+, [#45](https://github.com/PsychQuant/che-word-mcp/issues/45))**: Generate Word-native reviewable redlines via `insert_text_as_revision` / `delete_text_as_revision` / `move_text_as_revision`, plus `as_revision: true` flag on `format_text` / `set_paragraph_format`. Emits `<w:ins>` / `<w:del>` / `<w:moveFrom>` / `<w:moveTo>` / `<w:rPrChange>` / `<w:pPrChange>` markup. Side-effect contract: `as_revision: true` requires track changes enabled; throws `track_changes_not_enabled` otherwise (no silent auto-enable). Author resolution: explicit arg → `revisions.settings.author` → `"Unknown"`.
@@ -177,13 +177,13 @@ search_text: { "source_path": "/path/to/file.docx", "query": "keyword" }
 get_document_info: { "source_path": "/path/to/file.docx" }
 ```
 
-**18 tools support Direct Mode:**
+**19 tools support Direct Mode:**
 
 | Category | Tools |
 |----------|-------|
 | Read content | `get_text`, `get_document_text`, `get_paragraphs`, `get_document_info`, `search_text` |
 | List elements | `list_images`, `list_styles`, `get_tables`, `list_comments`, `list_hyperlinks`, `list_bookmarks`, `list_footnotes`, `list_endnotes`, `get_revisions` |
-| Properties | `get_document_properties`, `get_section_properties`, `get_word_count_by_section` |
+| Properties | `get_document_properties`, `get_section_properties`, `get_word_count_by_section`, `estimate_paragraph_for_page` |
 | Export | `export_markdown` |
 
 ### Session Mode (`doc_id`) — Full read/write lifecycle
@@ -236,7 +236,7 @@ curl -o .claude/skills/che-word-mcp/SKILL.md \
   https://raw.githubusercontent.com/PsychQuant/che-word-mcp/main/skills/che-word-mcp/SKILL.md
 ```
 
-## Available Tools (233 Total)
+## Available Tools (234 Total)
 
 ### Document Management (6 tools)
 
@@ -259,12 +259,13 @@ curl -o .claude/skills/che-word-mcp/SKILL.md \
 | `reload_from_disk` | Cooperative reload; requires `force: true` on dirty doc |
 | `check_disk_drift` | Informational — returns `{ drifted, disk_mtime, stored_mtime, disk_hash_matches }` |
 
-### Content Operations (8 tools)
+### Content Operations (9 tools)
 
 | Tool | Description |
 |------|-------------|
 | `get_text` | Get plain text content |
 | `get_paragraphs` | Get all paragraphs with formatting |
+| `estimate_paragraph_for_page` | **v3.18.0+** — estimate a Word UI page number to a `get_paragraphs` candidate range (heuristic JSON with confidence + warning) |
 | `insert_paragraph` | Insert a new paragraph |
 | `update_paragraph` | Update paragraph content |
 | `delete_paragraph` | Delete a paragraph |

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -3988,6 +3988,36 @@ actor WordMCPServer {
                 ])
             ),
             Tool(
+                name: "estimate_paragraph_for_page",
+                description: "估算 Word UI 第 N 頁大約落在哪些 get_paragraphs 段落索引。OOXML 不儲存頁面邊界；此工具使用 section page size / margins 與字元數啟發式估計，回傳 JSON、confidence 與 warning（支援 Direct Mode）。",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("文件識別碼（Session Mode）")
+                        ]),
+                        "source_path": .object([
+                            "type": .string("string"),
+                            "description": .string("檔案路徑（Direct Mode，免開啟）")
+                        ]),
+                        "page": .object([
+                            "type": .string("integer"),
+                            "description": .string("Word UI 頁碼（1-based；page=1 表示第一頁）")
+                        ]),
+                        "chars_per_page": .object([
+                            "type": .string("integer"),
+                            "description": .string("可選校準值。若提供，直接使用此每頁字元數；否則依 section page size / margins 估算。")
+                        ]),
+                        "context_paragraphs": .object([
+                            "type": .string("integer"),
+                            "description": .string("可選，向前/向後擴張的段落數（預設 2；設 0 可取得純估計範圍）")
+                        ])
+                    ]),
+                    "required": .array([.string("page")])
+                ])
+            ),
+            Tool(
                 name: "compare_documents",
                 description: "比對兩個 Word 文件的差異（段落層級），只回傳差異部分。支援文字、格式、結構比對模式",
                 inputSchema: .object([
@@ -6064,6 +6094,8 @@ actor WordMCPServer {
             return try await listAllFormattedText(args: args)
         case "get_word_count_by_section":
             return try await getWordCountBySection(args: args)
+        case "estimate_paragraph_for_page":
+            return try await estimateParagraphForPage(args: args)
         case "compare_documents":
             return try await compareDocuments(args: args)
 
@@ -11048,6 +11080,129 @@ actor WordMCPServer {
         output += "  Total: \(formatNumber(totalWords)) words\n"
 
         return output
+    }
+
+    // #89 — Estimate a Word UI page reference back to get_paragraphs indices.
+    // OOXML stores content, not rendered page boundaries; this intentionally
+    // returns a candidate range with confidence/warning rather than a precise
+    // paragraph anchor.
+    private func estimateParagraphForPage(args: [String: Value]) async throws -> String {
+        let (doc, _) = try await resolveDocument(args: args)
+
+        guard let page = args["page"]?.intValue else {
+            throw WordError.missingParameter("page")
+        }
+        guard page >= 1 else {
+            return "Error: estimate_paragraph_for_page: page must be >= 1"
+        }
+
+        let charsPerPage: Int
+        let layoutBasis: String
+        if let override = args["chars_per_page"]?.intValue {
+            guard override > 0 else {
+                return "Error: estimate_paragraph_for_page: chars_per_page must be > 0"
+            }
+            charsPerPage = override
+            layoutBasis = "caller_chars_per_page"
+        } else {
+            charsPerPage = Self.estimateCharsPerPage(from: doc.sectionProperties)
+            layoutBasis = "section_properties"
+        }
+
+        let contextParagraphs = args["context_paragraphs"]?.intValue ?? 2
+        guard contextParagraphs >= 0 else {
+            return "Error: estimate_paragraph_for_page: context_paragraphs must be >= 0"
+        }
+
+        let paragraphs = doc.getParagraphs()
+        guard !paragraphs.isEmpty else {
+            return try Self.renderJSONString([
+                "error": "empty_document",
+                "estimated_paragraph_range": [],
+                "confidence": "low",
+                "method": "char_count_heuristic",
+                "assumed_chars_per_page": charsPerPage,
+                "warning": Self.pageEstimateWarning,
+            ])
+        }
+
+        var spans: [(start: Int, end: Int)] = []
+        var cumulative = 0
+        for para in paragraphs {
+            let count = Self.estimatedLayoutCharacterCount(for: para)
+            let start = cumulative
+            cumulative += count
+            spans.append((start: start, end: cumulative))
+        }
+
+        let targetStart = (page - 1) * charsPerPage
+        let targetEnd = page * charsPerPage
+        let estimatedTotalPages = max(1, Int(ceil(Double(cumulative) / Double(charsPerPage))))
+        let beyondEstimatedDocument = targetStart >= cumulative
+
+        let rawStart: Int
+        let rawEnd: Int
+        if beyondEstimatedDocument {
+            rawStart = paragraphs.count - 1
+            rawEnd = paragraphs.count - 1
+        } else {
+            rawStart = spans.firstIndex { $0.end > targetStart } ?? (paragraphs.count - 1)
+            rawEnd = spans.lastIndex { $0.start < targetEnd } ?? rawStart
+        }
+
+        let startIndex = max(0, rawStart - contextParagraphs)
+        let endIndex = min(paragraphs.count - 1, rawEnd + contextParagraphs)
+        let confidence = (!beyondEstimatedDocument && layoutBasis == "section_properties" && paragraphs.count >= 3)
+            ? "medium"
+            : "low"
+
+        return try Self.renderJSONString([
+            "estimated_paragraph_range": [startIndex, endIndex],
+            "raw_estimated_paragraph_range": [rawStart, rawEnd],
+            "confidence": confidence,
+            "method": "char_count_heuristic",
+            "layout_basis": layoutBasis,
+            "page": page,
+            "assumed_chars_per_page": charsPerPage,
+            "estimated_total_pages": estimatedTotalPages,
+            "paragraph_count": paragraphs.count,
+            "total_estimated_chars": cumulative,
+            "context_paragraphs": contextParagraphs,
+            "requested_page_beyond_estimated_document": beyondEstimatedDocument,
+            "warning": Self.pageEstimateWarning,
+        ])
+    }
+
+    private static let pageEstimateWarning = "OOXML does not store page boundaries; this is an estimate based on character density and section page setup. Actual page boundaries depend on rendering, fonts, margins, line spacing, images, tables, and Word layout."
+
+    private static func estimatedLayoutCharacterCount(for paragraph: Paragraph) -> Int {
+        let text = paragraph.getText().replacingOccurrences(of: "\n", with: " ")
+        // Empty paragraphs still consume vertical space, so count them as a
+        // small visible unit plus a paragraph break.
+        return max(text.count, 1) + 1
+    }
+
+    private static func estimateCharsPerPage(from props: SectionProperties) -> Int {
+        let usableWidthTwips = max(
+            1440,
+            props.pageSize.width - props.pageMargins.left - props.pageMargins.right - props.pageMargins.gutter
+        )
+        let usableHeightTwips = max(
+            1440,
+            props.pageSize.height - props.pageMargins.top - props.pageMargins.bottom
+        )
+
+        // Conservative 12pt thesis/review calibration: average character width
+        // ~11pt, line height ~24pt. This intentionally favors a candidate range
+        // over a false-precise point estimate.
+        let charsPerLine = max(20, usableWidthTwips / 220)
+        let linesPerPage = max(10, usableHeightTwips / 480)
+        return max(400, charsPerLine * linesPerPage)
+    }
+
+    private static func renderJSONString(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 
     // Helper: 計算字數（支援中英文混合）

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -11092,15 +11092,20 @@ actor WordMCPServer {
         guard let page = args["page"]?.intValue else {
             throw WordError.missingParameter("page")
         }
-        guard page >= 1 else {
-            return "Error: estimate_paragraph_for_page: page must be >= 1"
+        // Upper-bound guard prevents (page - 1) * charsPerPage and page * charsPerPage
+        // from triggering Int overflow trap on caller-controlled Int.max input.
+        // 100_000 pages exceeds any real document by ~3 orders of magnitude.
+        guard page >= 1 && page <= 100_000 else {
+            return "Error: estimate_paragraph_for_page: page must be 1..100000, got \(page)"
         }
 
         let charsPerPage: Int
         let layoutBasis: String
         if let override = args["chars_per_page"]?.intValue {
-            guard override > 0 else {
-                return "Error: estimate_paragraph_for_page: chars_per_page must be > 0"
+            // Same overflow concern: page * charsPerPage with charsPerPage=Int.max.
+            // 200_000 chars/page is far beyond any plausible single-page density.
+            guard override > 0 && override <= 200_000 else {
+                return "Error: estimate_paragraph_for_page: chars_per_page must be 1..200000, got \(override)"
             }
             charsPerPage = override
             layoutBasis = "caller_chars_per_page"
@@ -11110,8 +11115,10 @@ actor WordMCPServer {
         }
 
         let contextParagraphs = args["context_paragraphs"]?.intValue ?? 2
-        guard contextParagraphs >= 0 else {
-            return "Error: estimate_paragraph_for_page: context_paragraphs must be >= 0"
+        // Upper bound prevents rawStart - contextParagraphs underflow and
+        // rawEnd + contextParagraphs overflow on Int.max input.
+        guard contextParagraphs >= 0 && contextParagraphs <= 1024 else {
+            return "Error: estimate_paragraph_for_page: context_paragraphs must be 0..1024, got \(contextParagraphs)"
         }
 
         let paragraphs = doc.getParagraphs()

--- a/Tests/CheWordMCPTests/Issue89EstimateParagraphForPageTests.swift
+++ b/Tests/CheWordMCPTests/Issue89EstimateParagraphForPageTests.swift
@@ -69,7 +69,7 @@ final class Issue89EstimateParagraphForPageTests: XCTestCase {
                 "page": .int(0)
             ]
         )
-        XCTAssertTrue(textOf(invalidPage).contains("page must be >= 1"))
+        XCTAssertTrue(textOf(invalidPage).contains("page must be"))
 
         let invalidCalibration = await server.invokeToolForTesting(
             name: "estimate_paragraph_for_page",
@@ -79,7 +79,74 @@ final class Issue89EstimateParagraphForPageTests: XCTestCase {
                 "chars_per_page": .int(0)
             ]
         )
-        XCTAssertTrue(textOf(invalidCalibration).contains("chars_per_page must be > 0"))
+        XCTAssertTrue(textOf(invalidCalibration).contains("chars_per_page must be"))
+    }
+
+    // MARK: - Int.max overflow regression (P1 from 6-AI verify)
+
+    func testEstimateParagraphForPageRejectsHugePage() async throws {
+        // Pre-fix: `(page - 1) * charsPerPage` and `page * charsPerPage` with
+        // page = Int.max trapped on arithmetic overflow → MCP server actor
+        // crashed. Post-fix clamps page to 1..100_000.
+        let url = try docxWithFixedParagraphs(count: 1, charsPerParagraphBeforeBreak: 10)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let result = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(.max)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertTrue(
+            text.contains("page must be") && text.contains("100000"),
+            "expected structured upper-bound rejection, got: \(text)"
+        )
+    }
+
+    func testEstimateParagraphForPageRejectsHugeCharsPerPage() async throws {
+        // Same overflow concern with chars_per_page = Int.max.
+        let url = try docxWithFixedParagraphs(count: 1, charsPerParagraphBeforeBreak: 10)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let result = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(1),
+                "chars_per_page": .int(.max)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertTrue(
+            text.contains("chars_per_page must be") && text.contains("200000"),
+            "expected structured upper-bound rejection, got: \(text)"
+        )
+    }
+
+    func testEstimateParagraphForPageRejectsHugeContextParagraphs() async throws {
+        // Pre-fix: `rawStart - contextParagraphs` underflow + `rawEnd +
+        // contextParagraphs` overflow on Int.max. Post-fix clamps to 0..1024.
+        let url = try docxWithFixedParagraphs(count: 1, charsPerParagraphBeforeBreak: 10)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let result = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(1),
+                "context_paragraphs": .int(.max)
+            ]
+        )
+        let text = textOf(result)
+        XCTAssertTrue(
+            text.contains("context_paragraphs must be") && text.contains("1024"),
+            "expected structured upper-bound rejection, got: \(text)"
+        )
     }
 
     func testEstimateParagraphForPageSchemaDocumentsHeuristicWarning() throws {

--- a/Tests/CheWordMCPTests/Issue89EstimateParagraphForPageTests.swift
+++ b/Tests/CheWordMCPTests/Issue89EstimateParagraphForPageTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import MCP
+import OOXMLSwift
+@testable import CheWordMCP
+
+/// PsychQuant/che-word-mcp#89 — floating comments often reference "page N"
+/// even though OOXML has no rendered page boundary. This tool narrows that
+/// page reference to a get_paragraphs candidate range.
+final class Issue89EstimateParagraphForPageTests: XCTestCase {
+
+    func testEstimateParagraphForPageUsesOneBasedPagesAndCallerCalibration() async throws {
+        let url = try docxWithFixedParagraphs(count: 12, charsPerParagraphBeforeBreak: 99)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let result = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(2),
+                "chars_per_page": .int(300),
+                "context_paragraphs": .int(0)
+            ]
+        )
+
+        let json = try jsonObject(from: textOf(result))
+        XCTAssertEqual(intArray(json["estimated_paragraph_range"]), [3, 5])
+        XCTAssertEqual(intArray(json["raw_estimated_paragraph_range"]), [3, 5])
+        XCTAssertEqual(json["method"] as? String, "char_count_heuristic")
+        XCTAssertEqual(json["layout_basis"] as? String, "caller_chars_per_page")
+        XCTAssertEqual(json["assumed_chars_per_page"] as? Int, 300)
+        XCTAssertEqual(json["page"] as? Int, 2)
+        XCTAssertEqual(json["paragraph_count"] as? Int, 12)
+        XCTAssertEqual(json["estimated_total_pages"] as? Int, 4)
+        XCTAssertEqual(json["requested_page_beyond_estimated_document"] as? Bool, false)
+        XCTAssertTrue((json["warning"] as? String ?? "").contains("OOXML does not store page boundaries"))
+    }
+
+    func testEstimateParagraphForPageMarksBeyondEstimatedDocument() async throws {
+        let url = try docxWithFixedParagraphs(count: 12, charsPerParagraphBeforeBreak: 99)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let result = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(10),
+                "chars_per_page": .int(300),
+                "context_paragraphs": .int(0)
+            ]
+        )
+
+        let json = try jsonObject(from: textOf(result))
+        XCTAssertEqual(intArray(json["estimated_paragraph_range"]), [11, 11])
+        XCTAssertEqual(json["requested_page_beyond_estimated_document"] as? Bool, true)
+        XCTAssertEqual(json["confidence"] as? String, "low")
+    }
+
+    func testEstimateParagraphForPageRejectsInvalidPageAndCalibration() async throws {
+        let url = try docxWithFixedParagraphs(count: 1, charsPerParagraphBeforeBreak: 10)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let server = await WordMCPServer()
+        let invalidPage = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(0)
+            ]
+        )
+        XCTAssertTrue(textOf(invalidPage).contains("page must be >= 1"))
+
+        let invalidCalibration = await server.invokeToolForTesting(
+            name: "estimate_paragraph_for_page",
+            arguments: [
+                "source_path": .string(url.path),
+                "page": .int(1),
+                "chars_per_page": .int(0)
+            ]
+        )
+        XCTAssertTrue(textOf(invalidCalibration).contains("chars_per_page must be > 0"))
+    }
+
+    func testEstimateParagraphForPageSchemaDocumentsHeuristicWarning() throws {
+        let source = try String(contentsOf: repoRoot().appendingPathComponent("Sources/CheWordMCP/Server.swift"), encoding: .utf8)
+        XCTAssertTrue(source.contains("name: \"estimate_paragraph_for_page\""))
+        XCTAssertTrue(source.contains("OOXML 不儲存頁面邊界"))
+        XCTAssertTrue(source.contains("Word UI 頁碼（1-based"))
+        XCTAssertTrue(source.contains("chars_per_page"))
+        XCTAssertTrue(source.contains("context_paragraphs"))
+    }
+
+    private func docxWithFixedParagraphs(count: Int, charsPerParagraphBeforeBreak: Int) throws -> URL {
+        var doc = WordDocument()
+        let text = String(repeating: "x", count: charsPerParagraphBeforeBreak)
+        for _ in 0..<count {
+            doc.body.children.append(.paragraph(Paragraph(runs: [Run(text: text)])))
+        }
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue89_page_estimate_\(UUID().uuidString).docx")
+        try DocxWriter.write(doc, to: url)
+        return url
+    }
+
+    private func textOf(_ r: CallTool.Result) -> String {
+        r.content.compactMap { item -> String? in
+            if case let .text(t, _, _) = item { return t } else { return nil }
+        }.joined(separator: "\n")
+    }
+
+    private func jsonObject(from text: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(text.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func intArray(_ value: Any?) -> [Int] {
+        (value as? [Any])?.compactMap { ($0 as? NSNumber)?.intValue } ?? []
+    }
+
+    private func repoRoot() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.pathComponents.count > 1 {
+            url = url.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: url.appendingPathComponent("Package.swift").path) {
+                return url
+            }
+        }
+        return URL(fileURLWithPath: "/dev/null")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `estimate_paragraph_for_page` for floating comments that reference "page N" without a concrete OOXML anchor.
- Returns parseable JSON with candidate `get_paragraphs` range, confidence, calibration method, estimated total pages, and an explicit OOXML page-boundary warning.
- Supports both Direct Mode (`source_path`) and Session Mode (`doc_id`), plus optional `chars_per_page` and `context_paragraphs` calibration.

Refs #89

## Tests

- `swift test --filter Issue89EstimateParagraphForPageTests`
