### PR TITLE
fix: caption detection uses Paragraph.style + expanded prefix set with digit guard

### DIFF
--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -10753,7 +10753,9 @@ actor WordMCPServer {
         func scanParagraph(_ para: Paragraph, paragraphIndex: Int?, location: String) {
             let text = para.flattenedDisplayText()
             guard !text.isEmpty else { return }
-            if excludeTableCaptions && isLikelyTableCaption(text) { return }
+            // #136: pass paragraph (not text) so isLikelyTableCaption can check
+            // Paragraph.properties.style as primary signal, with text-prefix fallback.
+            if excludeTableCaptions && isLikelyTableCaption(para) { return }
 
             let chars = Array(text)
             var i = 0
@@ -10845,14 +10847,96 @@ actor WordMCPServer {
         return "[\(entries.joined(separator: ","))]"
     }
 
-    private func isLikelyTableCaption(_ text: String) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// Detects whether a paragraph is likely a Word caption (Table / Figure / 表 / 圖 / etc.).
+    ///
+    /// Two-layer detection (#136 fix; verify finding from #112):
+    ///
+    /// **Layer 1 — Paragraph.style (primary, ground truth)**: Word's `Caption`
+    /// style is the canonical OOXML signal. Substring match on lowercased
+    /// style name catches `Caption`, `ImageCaption`, `TableCaption`, etc.
+    ///
+    /// **Layer 2 — text prefix (fallback)**: covers paragraphs without
+    /// explicit style attribute (e.g. parsed from imported docx). Expanded
+    /// from 5 to 11 prefix variants to cover Figure / Tab. / Fig. / Listing
+    /// + CJK U+3000 ideographic space + 表数字 / 圖数字 (no separator).
+    ///
+    /// **False-positive guard**: previous text-only impl (`hasPrefix("Table ")`)
+    /// matched body sentences like "Table reservations are required..."
+    /// when no style was set. Layer 1 fires only on style match, so a
+    /// `Heading 1`-styled paragraph beginning with "table" is NOT skipped.
+    ///
+    /// `internal` (not `private`) so `@testable import` tests can exercise
+    /// the heuristic directly without spinning up the full MCP server.
+    internal func isLikelyTableCaption(_ paragraph: Paragraph) -> Bool {
+        // Layer 1: style-based detection (primary)
+        if let style = paragraph.properties.style?.lowercased(),
+           style.contains("caption") {
+            return true
+        }
+
+        // Layer 2: expanded prefix fallback with digit-after-prefix guard
+        //
+        // The digit guard fixes the pre-existing false-positive case where
+        // body sentences starting with "Table " (e.g. "Table reservations are
+        // required..." or "Table of contents") were misidentified as captions.
+        // Real captions virtually always have a number after the prefix:
+        // "Table 1", "Figure 2", "圖 1", "表3-1". Body sentences don't.
+        let trimmed = paragraph.flattenedDisplayText().trimmingCharacters(in: .whitespacesAndNewlines)
         let lower = trimmed.lowercased()
-        return lower.hasPrefix("table ")
-            || lower.hasPrefix("table\t")
-            || trimmed.hasPrefix("表 ")
-            || trimmed.hasPrefix("表\t")
-            || trimmed.hasPrefix("表格")
+
+        // Helper: char immediately after a matched prefix is a digit.
+        func nextCharIsDigit(after prefix: String, in source: String) -> Bool {
+            guard source.count > prefix.count else { return false }
+            let idx = source.index(source.startIndex, offsetBy: prefix.count)
+            return source[idx].isNumber
+        }
+
+        // English caption prefixes (case-insensitive) — require digit follow-up
+        let englishPrefixes = ["table ", "table\t", "figure ", "figure\t", "tab. ", "fig. ", "listing "]
+        for prefix in englishPrefixes where lower.hasPrefix(prefix) {
+            if nextCharIsDigit(after: prefix, in: lower) {
+                return true
+            }
+            // Matched prefix but no digit after → likely body text ("Table of contents",
+            // "Figure shows that..."). Don't return true; fall through to other layers
+            // (none, but be explicit).
+            return false
+        }
+
+        // CJK caption prefixes — separator variants + U+3000 ideographic space
+        // Same digit-after-prefix guard for symmetry.
+        let cjkPrefixes = [
+            "表 ", "表\t", "表\u{3000}",
+            "圖 ", "圖\t", "圖\u{3000}",
+            "图 ", "图\t", "图\u{3000}"
+        ]
+        for prefix in cjkPrefixes where trimmed.hasPrefix(prefix) {
+            if nextCharIsDigit(after: prefix, in: trimmed) {
+                return true
+            }
+            return false
+        }
+
+        // 表格 / 图表 — multi-char CJK forms commonly used as caption labels
+        // (less ambiguous than bare 表 / 圖). Keep accepting these without digit guard.
+        if trimmed.hasPrefix("表格") || trimmed.hasPrefix("图表") {
+            return true
+        }
+
+        // CJK no-separator forms: 表3-1 / 圖1 / 图2.5
+        // Match `^[表圖图]\d` (prefix is one CJK char + digit; covers 表3-1, 圖1.2, 图2;
+        // excludes 表面 / 圖案 / 图案 since second char must be digit).
+        if let firstChar = trimmed.first,
+           "表圖图".contains(firstChar),
+           trimmed.count >= 2 {
+            let secondIndex = trimmed.index(after: trimmed.startIndex)
+            let secondChar = trimmed[secondIndex]
+            if secondChar.isNumber {
+                return true
+            }
+        }
+
+        return false
     }
 
     // 9.4 list_hyperlinks - 列出所有超連結

--- a/Tests/CheWordMCPTests/Issue136CaptionDetectionTests.swift
+++ b/Tests/CheWordMCPTests/Issue136CaptionDetectionTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+import OOXMLSwift
+@testable import CheWordMCP
+
+/// PsychQuant/che-word-mcp#136 — `find_inline_math_gaps` caption detection
+/// must use `Paragraph.style` as primary signal + handle expanded prefix set
+/// (Tab. / Fig. / 圖 / U+3000 ideographic space / 表3-1 no-separator forms).
+///
+/// Verify finding from #112: text-only heuristic produced false negatives
+/// (Figure 1 / Tab. 1 / 表3-1 / 表　1 / Caption-styled body text) AND
+/// false positives ("Table reservations are required..." mistaken as caption).
+///
+/// Two-layer detection:
+/// - Layer 1: `paragraph.properties.style?.lowercased().contains("caption")` (primary, ground truth)
+/// - Layer 2: expanded text prefix fallback (when style absent)
+final class Issue136CaptionDetectionTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func paragraph(text: String, style: String? = nil) -> Paragraph {
+        var para = Paragraph(runs: [Run(text: text)])
+        if let style {
+            para.properties.style = style
+        }
+        return para
+    }
+
+    // MARK: - Layer 1 (style-based) tests
+
+    func testCaptionStyleSkippedRegardlessOfText() async throws {
+        let server = await WordMCPServer()
+        // Body text doesn't look like caption, but style says it is.
+        let para = paragraph(text: "Some statistics here", style: "Caption")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "Paragraph with style='Caption' should be detected as caption regardless of body text content")
+    }
+
+    func testImageCaptionStyleSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "本圖示意架構", style: "ImageCaption")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "Paragraph with style='ImageCaption' (substring 'caption') should be detected")
+    }
+
+    func testTableCaptionStyleCaseInsensitive() async throws {
+        let server = await WordMCPServer()
+        // Lower-case style name (some imports use lowercased ids)
+        let para = paragraph(text: "Description without prefix", style: "tablecaption")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "Style match should be case-insensitive (lowercased contains 'caption')")
+    }
+
+    func testHeadingStyleNotSkippedDespiteTablePrefix() async throws {
+        let server = await WordMCPServer()
+        // Style says heading; text accidentally starts with "table" (e.g. "Table of contents")
+        let para = paragraph(text: "Table of contents", style: "Heading 1")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption,
+            "Heading-styled paragraph must NOT be skipped even if text starts with 'table'")
+    }
+
+    // MARK: - Layer 2 (prefix fallback) tests — no style set
+
+    func testFigurePrefixSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "Figure 1: model architecture")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "'Figure 1' prefix (no style) must be detected as caption")
+    }
+
+    func testTabAbbreviationPrefixSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "Tab. 1 — Summary statistics")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "'Tab. ' (English journal abbreviation) prefix must be detected")
+    }
+
+    func testFigAbbreviationPrefixSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "Fig. 2: experimental setup")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption, "'Fig. ' (English journal abbreviation) prefix must be detected")
+    }
+
+    func testListingPrefixSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "Listing 1: example code")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption, "'Listing 1' (code-listing convention) must be detected")
+    }
+
+    func testIdeographicSpacePrefixSkipped() async throws {
+        let server = await WordMCPServer()
+        // U+3000 ideographic space (CJK common)
+        let para = paragraph(text: "表\u{3000}1：實驗結果")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption,
+            "'表' + U+3000 ideographic space prefix must be detected (CJK common usage)")
+    }
+
+    func testCJKDirectDigitPrefixTable() async throws {
+        let server = await WordMCPServer()
+        // No separator: 表3-1 (academic CJK common)
+        let para = paragraph(text: "表3-1：模型參數")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption, "'表3-1' (no-separator CJK form) must be detected")
+    }
+
+    func testCJKDirectDigitPrefixFigure() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "圖1.2 系統架構")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption, "'圖1.2' (no-separator CJK form) must be detected")
+    }
+
+    func testSimplifiedChineseFigurePrefix() async throws {
+        let server = await WordMCPServer()
+        // Simplified Chinese 图 (U+56FE)
+        let para = paragraph(text: "图 1：算法流程")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertTrue(isCaption, "Simplified Chinese '图 1' must be detected")
+    }
+
+    // MARK: - Negative cases (false-positive guard)
+
+    func testTableBodyTextNotSkipped() async throws {
+        let server = await WordMCPServer()
+        // Body sentence starting with "Table " but NOT followed by a digit.
+        // Pre-#136-fix: was incorrectly skipped (false positive).
+        // Post-fix: digit-after-prefix guard rejects this (Layer 2 returns false).
+        let para = paragraph(text: "Table reservations are required for groups of 6 or more.")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption,
+            "'Table ' prefix without digit follow-up (e.g. 'Table reservations...') " +
+            "must NOT be detected as caption. Real captions are 'Table 1', 'Table 2-1', etc.")
+    }
+
+    func testFigureShowsThatNotSkipped() async throws {
+        let server = await WordMCPServer()
+        // Body sentence starting with "Figure " but no digit
+        let para = paragraph(text: "Figure shows that the trend is increasing.")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption,
+            "'Figure ' followed by non-digit text must NOT be detected (Layer 2 digit guard)")
+    }
+
+    func testNonCaptionTextWithoutPrefixNotSkipped() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "This is a regular paragraph with no caption hints.")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption,
+            "Plain body text without caption prefix and without style must NOT be skipped")
+    }
+
+    func testCJKBodyTextWithoutDigit() async throws {
+        let server = await WordMCPServer()
+        // 表面 = "surface" — body word, not a caption
+        let para = paragraph(text: "表面溫度需要保持穩定")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption,
+            "'表面' (surface) starts with 表 but second char is not digit → not a caption. " +
+            "Same guard for 圖案/图案 etc.")
+    }
+
+    func testEmptyParagraph() async throws {
+        let server = await WordMCPServer()
+        let para = paragraph(text: "")
+        let isCaption = await server.isLikelyTableCaption(para)
+        XCTAssertFalse(isCaption, "Empty paragraph must NOT be detected as caption")
+    }
+}


### PR DESCRIPTION
Refs #136

## Summary

Fixes caption-detection heuristic in `findInlineMathGaps`. Two-layer detection:
- **Layer 1**: `Paragraph.style` (primary signal — Word's `Caption`/`ImageCaption`/`TableCaption` ground truth)
- **Layer 2**: expanded text prefix fallback with digit-after-prefix guard

Closes both pre-existing failure modes from #112 verify:
- **False negatives**: `Figure 1`, `Tab. 1`, `表3-1`, `表　1` (U+3000), `Caption`-styled body text
- **False positives**: `Table reservations are required...`, `Figure shows that...`

## Key changes

- `isLikelyTableCaption(_ text: String) -> Bool` → `(_ paragraph: Paragraph) -> Bool` (private → internal for `@testable`)
- Layer 1: lowercased style contains `"caption"` (catches `Caption` / `ImageCaption` / `TableCaption` etc.)
- Layer 2: 7 English prefixes + 9 CJK prefixes + CJK no-separator regex + label-only `表格`/`图表`
- Digit-after-prefix guard rejects body sentences

## Test Plan

- [x] 17 new tests in `Issue136CaptionDetectionTests.swift` (Layer 1 + Layer 2 + negatives)
- [x] `swift test --filter Issue136`: 17/17 pass
- [x] `swift test` full: 283/0 fail (9 pre-existing skips)
- [ ] **Pending**: human review + `/idd-verify #136` 6-AI ensemble + `/idd-close #136` after merge

## Thesis impact (per user request)

Guo's thesis docx captions (圖 1.1 / 表 3.2 / Tab. 1) now correctly excluded from inline-math-gap scan; body text starting with "Table" / "Figure" no longer false-positive.

---

🤖 Generated by /idd-implement on PR path. **Do NOT add 'Closes #136'** — IDD discipline requires manual `/idd-close` after merge.