### PR TITLE
feat: splice_omath_from_source MCP tools wrap ooxml-swift v0.24.0 spliceOMath (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.0] - 2026-05-04
+
+### Added — `splice_omath_from_source` + `splice_paragraph_omath_from_source` MCP tools (closes [#160](https://github.com/PsychQuant/che-word-mcp/issues/160))
+
+Two new MCP tools wrapping ooxml-swift v0.24.0's [`spliceOMath`](https://github.com/PsychQuant/ooxml-swift/issues/57) API for cross-document verbatim copy of `<m:oMath>` XML blocks. Unblocks the kiki830621/collaboration_guo_analysis Phase 7 inline-math restoration pipeline.
+
+#### `splice_omath_from_source` (single-OMath, low-level)
+
+```typescript
+{
+  // Source side (one of):
+  source_path?: string,        // Direct mode (read-only, opens temporarily)
+  source_doc_id?: string,      // Session mode (already-open doc)
+  source_paragraph_index: number,    // body-paragraph index in source
+
+  // Target side (Session mode required):
+  doc_id: string,
+  target_paragraph_index: number,
+
+  // Splice config:
+  position: "atStart" | "atEnd" | "afterText" | "beforeText",
+  anchor?: string,             // required when position="afterText" / "beforeText"
+  instance?: number,           // 1-based anchor occurrence (default 1)
+  omath_index?: number,        // 0-based, default 0 (joint document-order across both source carriers)
+  rpr_mode?: "full" | "omathOnly" | "discard",  // default "full"
+  namespace_policy?: "lenient" | "strict"        // default "lenient"
+}
+```
+
+Returns `Spliced 1 OMath block (...)` on success or structured `Error: splice_omath_from_source: ...` on failure (covers `sourceHasNoOMath` / `omathIndexOutOfRange` / `targetParagraphOutOfRange` / `anchorNotFound` / `namespaceMismatch`).
+
+#### `splice_paragraph_omath_from_source` (paragraph-level batch, high-level)
+
+Same surface as `splice_omath_from_source` minus `position` / `anchor` / `instance` / `omath_index` — splices ALL OMath blocks from source paragraph in source-document order, auto-deriving anchor for each from ~10 chars of source-text-context. Returns `Spliced N OMath block(s) into target_paragraph_index=K` or `Error: ...: context anchor not found for omath_index=I, snippet='...'` (with partial-success state remaining in target).
+
+#### Tests
+
+`Issue160SpliceOMathFromSourceTests` — 8 cases covering Direct/Session source modes, atEnd / afterText positions, missing-arg / out-of-range / no-OMath errors, batch mode, and rPr `.discard` mode.
+
+#### Dependencies
+
+- ooxml-swift bumped from `0.21.0` → `0.24.0` (required by new splice API)
+- Full suite: 297 tests, 0 failures, 9 pre-existing skips
+
 ## [3.19.0] - 2026-05-04
 
 ### Fixed — `find_inline_math_gaps` caption detection (closes [#136](https://github.com/PsychQuant/che-word-mcp/issues/136))

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PsychQuant/ooxml-swift.git",
       "state" : {
-        "revision" : "2d373f0f058370a4f5f57011bd718b224234f58e",
-        "version" : "0.22.1"
+        "revision" : "a6ddb2e7b7c8e3f0db017fb1f489c73e4ff5ba98",
+        "version" : "0.24.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
-        .package(url: "https://github.com/PsychQuant/ooxml-swift.git", from: "0.21.0"),
+        .package(url: "https://github.com/PsychQuant/ooxml-swift.git", from: "0.24.0"),
         .package(url: "https://github.com/PsychQuant/markdown-swift.git", from: "0.2.0"),
         .package(url: "https://github.com/PsychQuant/word-to-md-swift.git", from: "0.6.1"),
         .package(url: "https://github.com/PsychQuant/latex-math-swift.git", from: "0.1.0"),

--- a/Sources/CheWordMCP/Server.swift
+++ b/Sources/CheWordMCP/Server.swift
@@ -5214,6 +5214,102 @@ actor WordMCPServer {
                 ])
             ),
 
+            // 12.1c splice_omath_from_source - 跨 doc 拷貝 verbatim <m:oMath> XML (Refs #160 / ooxml-swift#57)
+            Tool(
+                name: "splice_omath_from_source",
+                description: "v3.20.0+ (Refs #160 / ooxml-swift#57): 跨 document 拷貝 verbatim `<m:oMath>` XML 區塊。從 source paragraph 抽出第 N 個 OMath（按 source-document order，跨 Run.rawXML / unrecognizedChildren 兩種 carrier 統一排序），splice 進 target paragraph 的指定位置。Source 用 `source_path`（直接讀 disk）或 `source_doc_id`（已開啟的 doc）；target 必須是 session-mode `doc_id`。Position 支援 atStart / atEnd / afterText (anchor instance) / beforeText (anchor instance)。`rpr_mode` 控制 source Run rPr 怎麼帶到 target Run（full=verbatim default、omathOnly=白名單 rFonts/sz/lang/bold/italic、discard=空 rPr）。`namespace_policy` 預設 lenient（接受 m: vs mml: prefix 不同但 URI 相同）；strict 任何 prefix 不同就 throw。返回成功 splice 的 OMath 數量（單調 1）。",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "source_path": .object([
+                            "type": .string("string"),
+                            "description": .string("source docx 路徑（Direct mode；read-only）。與 source_doc_id 二擇一。")
+                        ]),
+                        "source_doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("已開啟之 source docx doc_id。與 source_path 二擇一。")
+                        ]),
+                        "source_paragraph_index": .object([
+                            "type": .string("integer"),
+                            "description": .string("source 中的 body-paragraph index（從 0 開始；只計 body.children 中的 .paragraph）")
+                        ]),
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("target doc_id（session mode；必須 already-open）")
+                        ]),
+                        "target_paragraph_index": .object([
+                            "type": .string("integer"),
+                            "description": .string("target 的 body-paragraph index（同 source_paragraph_index 計法）")
+                        ]),
+                        "position": .object([
+                            "type": .string("string"),
+                            "description": .string("splice 位置：'atStart' / 'atEnd' / 'afterText' / 'beforeText'。後兩者需配合 anchor + 可選 instance。")
+                        ]),
+                        "anchor": .object([
+                            "type": .string("string"),
+                            "description": .string("position=afterText/beforeText 時必填。target paragraph 的文字 anchor。")
+                        ]),
+                        "instance": .object([
+                            "type": .string("integer"),
+                            "description": .string("anchor 的第 N 次匹配（1-based，預設 1）")
+                        ]),
+                        "omath_index": .object([
+                            "type": .string("integer"),
+                            "description": .string("source paragraph 中第 N 個 OMath（0-based，預設 0；按 source-document order 跨 carrier 排序）")
+                        ]),
+                        "rpr_mode": .object([
+                            "type": .string("string"),
+                            "description": .string("source Run rPr 傳遞模式：'full'（預設，verbatim copy）、'omathOnly'（白名單 rFonts/sz/lang/bold/italic）、'discard'（空 rPr）")
+                        ]),
+                        "namespace_policy": .object([
+                            "type": .string("string"),
+                            "description": .string("namespace 處理模式：'lenient'（預設，URI 相同就接受）、'strict'（prefix 或 URI 不同就 throw）")
+                        ])
+                    ]),
+                    "required": .array([.string("doc_id"), .string("source_paragraph_index"), .string("target_paragraph_index"), .string("position")])
+                ])
+            ),
+
+            // 12.1d splice_paragraph_omath_from_source - paragraph-level batch (Refs #160 / ooxml-swift#57)
+            Tool(
+                name: "splice_paragraph_omath_from_source",
+                description: "v3.20.0+ (Refs #160 / ooxml-swift#57): paragraph-level batch — 把 source paragraph 內所有 OMath 區塊按 source-document order splice 到 target paragraph 對應位置（內部用 ~10 chars source-text-context 自動推 anchor）。回傳成功 splice 的 OMath 數量。任一 OMath 的 context anchor 在 target 找不到 → throw `contextAnchorNotFound(omath_index, snippet)`，partial-success state 已留在 target paragraph。",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "source_path": .object([
+                            "type": .string("string"),
+                            "description": .string("source docx 路徑（Direct mode；read-only）")
+                        ]),
+                        "source_doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("已開啟之 source docx doc_id")
+                        ]),
+                        "source_paragraph_index": .object([
+                            "type": .string("integer"),
+                            "description": .string("source 中的 body-paragraph index")
+                        ]),
+                        "doc_id": .object([
+                            "type": .string("string"),
+                            "description": .string("target doc_id（session mode；必須 already-open）")
+                        ]),
+                        "target_paragraph_index": .object([
+                            "type": .string("integer"),
+                            "description": .string("target 的 body-paragraph index")
+                        ]),
+                        "rpr_mode": .object([
+                            "type": .string("string"),
+                            "description": .string("rPr 傳遞模式：'full' (預設) / 'omathOnly' / 'discard'")
+                        ]),
+                        "namespace_policy": .object([
+                            "type": .string("string"),
+                            "description": .string("namespace 處理：'lenient' (預設) / 'strict'")
+                        ])
+                    ]),
+                    "required": .array([.string("doc_id"), .string("source_paragraph_index"), .string("target_paragraph_index")])
+                ])
+            ),
+
             // 12.2 insert_cross_reference - 插入交互參照
             Tool(
                 name: "insert_cross_reference",
@@ -6365,6 +6461,10 @@ actor WordMCPServer {
             return try await updateEquationHandler(args: args)
         case "delete_equation":
             return try await deleteEquationHandler(args: args)
+        case "splice_omath_from_source":
+            return try await spliceOMathFromSource(args: args)
+        case "splice_paragraph_omath_from_source":
+            return try await spliceParagraphOMathFromSource(args: args)
         case "insert_cross_reference":
             return try await insertCrossReference(args: args)
         case "insert_table_of_figures":
@@ -9339,6 +9439,159 @@ actor WordMCPServer {
         try await storeDocument(doc, for: docId)
 
         return "Inserted equation (display mode: \(displayMode), \(anchorInfo))"
+    }
+
+    // MARK: - splice_omath_from_source / splice_paragraph_omath_from_source (#160)
+
+    /// Resolve source paragraph from either source_path (Direct mode, read-only)
+    /// or source_doc_id (already-open doc). Returns the Paragraph.
+    private func resolveSourceParagraph(args: [String: Value]) async throws -> Paragraph {
+        guard let sourceParaIdx = args["source_paragraph_index"]?.intValue else {
+            throw WordError.missingParameter("source_paragraph_index")
+        }
+        let sourceDoc: WordDocument
+        if let sourcePath = args["source_path"]?.stringValue {
+            guard FileManager.default.fileExists(atPath: sourcePath) else {
+                throw WordError.fileNotFound(sourcePath)
+            }
+            sourceDoc = try DocxReader.read(from: URL(fileURLWithPath: sourcePath))
+        } else if let sourceDocId = args["source_doc_id"]?.stringValue {
+            guard let opened = openDocuments[sourceDocId] else {
+                throw WordError.documentNotFound(sourceDocId)
+            }
+            sourceDoc = opened
+        } else {
+            throw WordError.missingParameter("source_path or source_doc_id")
+        }
+
+        // Body-paragraph index (counts only `.paragraph` body children)
+        var paraCounter = 0
+        for child in sourceDoc.body.children {
+            if case .paragraph(let p) = child {
+                if paraCounter == sourceParaIdx { return p }
+                paraCounter += 1
+            }
+        }
+        throw WordError.invalidFormat("source_paragraph_index \(sourceParaIdx) out of range (only \(paraCounter) body paragraphs in source)")
+    }
+
+    private func parseRpRMode(_ s: String?) -> OMathSpliceRpRMode {
+        switch s {
+        case "omathOnly": return .omathOnly
+        case "discard":   return .discard
+        default:          return .full  // default + "full"
+        }
+    }
+
+    private func parseNamespacePolicy(_ s: String?) -> OMathSpliceNamespacePolicy {
+        s == "strict" ? .strict : .lenient
+    }
+
+    private func formatSpliceError(_ err: OMathSpliceError, tool: String) -> String {
+        switch err {
+        case .sourceHasNoOMath:
+            return "Error: \(tool): source paragraph contains no OMath blocks"
+        case .omathIndexOutOfRange(let req, let avail):
+            return "Error: \(tool): omath_index \(req) out of range (source has \(avail) OMath block\(avail == 1 ? "" : "s"))"
+        case .targetParagraphOutOfRange(let idx):
+            return "Error: \(tool): target_paragraph_index \(idx) out of range"
+        case .anchorNotFound(let anchor, let instance):
+            return "Error: \(tool): anchor '\(anchor)' not found in target paragraph (instance \(instance))"
+        case .namespaceMismatch(let src, let tgt):
+            return "Error: \(tool): namespace mismatch — source URI '\(src)' vs target URI '\(tgt)'"
+        case .contextAnchorNotFound(let i, let snippet):
+            return "Error: \(tool): context anchor not found for omath_index=\(i), snippet='\(snippet)' (advisor edit may have changed surrounding prose)"
+        }
+    }
+
+    private func spliceOMathFromSource(args: [String: Value]) async throws -> String {
+        guard let docId = args["doc_id"]?.stringValue else {
+            throw WordError.missingParameter("doc_id")
+        }
+        guard var target = openDocuments[docId] else {
+            throw WordError.documentNotFound(docId)
+        }
+        guard let targetParaIdx = args["target_paragraph_index"]?.intValue else {
+            throw WordError.missingParameter("target_paragraph_index")
+        }
+        guard let positionRaw = args["position"]?.stringValue else {
+            throw WordError.missingParameter("position")
+        }
+
+        let sourcePara = try await resolveSourceParagraph(args: args)
+
+        // Build OMathSplicePosition.
+        let position: OMathSplicePosition
+        let instance = args["instance"]?.intValue ?? 1
+        if instance < 1 {
+            return "Error: splice_omath_from_source: instance must be ≥ 1, got \(instance)"
+        }
+        switch positionRaw {
+        case "atStart":
+            position = .atStart
+        case "atEnd":
+            position = .atEnd
+        case "afterText":
+            guard let anchor = args["anchor"]?.stringValue, !anchor.isEmpty else {
+                return "Error: splice_omath_from_source: position='afterText' requires non-empty 'anchor' argument"
+            }
+            position = .afterText(anchor, instance: instance)
+        case "beforeText":
+            guard let anchor = args["anchor"]?.stringValue, !anchor.isEmpty else {
+                return "Error: splice_omath_from_source: position='beforeText' requires non-empty 'anchor' argument"
+            }
+            position = .beforeText(anchor, instance: instance)
+        default:
+            return "Error: splice_omath_from_source: position must be one of 'atStart' / 'atEnd' / 'afterText' / 'beforeText', got '\(positionRaw)'"
+        }
+
+        let omathIndex = args["omath_index"]?.intValue ?? 0
+        let rPrMode = parseRpRMode(args["rpr_mode"]?.stringValue)
+        let nsPolicy = parseNamespacePolicy(args["namespace_policy"]?.stringValue)
+
+        do {
+            let n = try target.spliceOMath(
+                from: sourcePara,
+                toBodyParagraphIndex: targetParaIdx,
+                position: position,
+                omathIndex: omathIndex,
+                rPrMode: rPrMode,
+                namespacePolicy: nsPolicy
+            )
+            try await storeDocument(target, for: docId)
+            return "Spliced \(n) OMath block (omath_index=\(omathIndex), position=\(positionRaw), rpr_mode=\(args["rpr_mode"]?.stringValue ?? "full"), namespace_policy=\(args["namespace_policy"]?.stringValue ?? "lenient"))"
+        } catch let err as OMathSpliceError {
+            return formatSpliceError(err, tool: "splice_omath_from_source")
+        }
+    }
+
+    private func spliceParagraphOMathFromSource(args: [String: Value]) async throws -> String {
+        guard let docId = args["doc_id"]?.stringValue else {
+            throw WordError.missingParameter("doc_id")
+        }
+        guard var target = openDocuments[docId] else {
+            throw WordError.documentNotFound(docId)
+        }
+        guard let targetParaIdx = args["target_paragraph_index"]?.intValue else {
+            throw WordError.missingParameter("target_paragraph_index")
+        }
+
+        let sourcePara = try await resolveSourceParagraph(args: args)
+        let rPrMode = parseRpRMode(args["rpr_mode"]?.stringValue)
+        let nsPolicy = parseNamespacePolicy(args["namespace_policy"]?.stringValue)
+
+        do {
+            let n = try target.spliceParagraphOMath(
+                from: sourcePara,
+                toBodyParagraphIndex: targetParaIdx,
+                rPrMode: rPrMode,
+                namespacePolicy: nsPolicy
+            )
+            try await storeDocument(target, for: docId)
+            return "Spliced \(n) OMath block(s) into target_paragraph_index=\(targetParaIdx) (rpr_mode=\(args["rpr_mode"]?.stringValue ?? "full"), namespace_policy=\(args["namespace_policy"]?.stringValue ?? "lenient"))"
+        } catch let err as OMathSpliceError {
+            return formatSpliceError(err, tool: "splice_paragraph_omath_from_source")
+        }
     }
 
     // MARK: - Math parsers (insert_equation helpers)

--- a/Tests/CheWordMCPTests/Issue160SpliceOMathFromSourceTests.swift
+++ b/Tests/CheWordMCPTests/Issue160SpliceOMathFromSourceTests.swift
@@ -1,0 +1,326 @@
+import XCTest
+import MCP
+import OOXMLSwift
+@testable import CheWordMCP
+
+/// PsychQuant/che-word-mcp#160 — `splice_omath_from_source` and
+/// `splice_paragraph_omath_from_source` MCP tools wrap ooxml-swift v0.24.0's
+/// `WordDocument.spliceOMath(...)` and `spliceParagraphOMath(...)` APIs
+/// (PsychQuant/ooxml-swift#57).
+///
+/// Tests cover:
+/// - Single-OMath splice via Direct mode (source_path) → Session mode (doc_id)
+/// - Single-OMath splice via Session mode (source_doc_id) → Session mode (doc_id)
+/// - Mid-paragraph anchor splice (afterText)
+/// - Paragraph-level batch splice
+/// - Error taxonomy: missing args, anchor not found, OMath index out of range,
+///   target paragraph index out of range, source has no OMath
+/// - rPr propagation modes (full / discard)
+/// - Namespace policy (lenient default / strict opt-out)
+final class Issue160SpliceOMathFromSourceTests: XCTestCase {
+
+    // MARK: - Fixture builders
+
+    private static let mNS = "xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\""
+
+    /// Build a one-paragraph source docx with inline OMath in a Run:
+    /// `<w:p><w:r>所得出的參數進行 </w:r><w:r><m:oMath>t</m:oMath></w:r><w:r> 檢定：</w:r></w:p>`
+    private func makeSourceDocxWithInlineOMath() throws -> URL {
+        var doc = WordDocument()
+        var run1 = Run(text: "所得出的參數進行 ")
+        run1.position = 1
+        var run2 = Run(text: "")
+        run2.rawXML = "<m:oMath \(Self.mNS)><m:r><m:t>t</m:t></m:r></m:oMath>"
+        run2.position = 2
+        var run3 = Run(text: " 檢定：")
+        run3.position = 3
+        let para = Paragraph(runs: [run1, run2, run3])
+        doc.body.children.append(.paragraph(para))
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue160-source-\(UUID().uuidString).docx")
+        try DocxWriter.write(doc, to: url)
+        return url
+    }
+
+    /// Build a target docx with corresponding prose anchor but no OMath
+    /// (the rescue-pipeline use case).
+    private func makeTargetDocxNoOMath() throws -> URL {
+        var doc = WordDocument()
+        var run = Run(text: "所得出的參數進行  檢定：")
+        run.position = 1
+        let para = Paragraph(runs: [run])
+        doc.body.children.append(.paragraph(para))
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue160-target-\(UUID().uuidString).docx")
+        try DocxWriter.write(doc, to: url)
+        return url
+    }
+
+    private func textOf(_ r: CallTool.Result) -> String {
+        r.content.compactMap { item -> String? in
+            if case let .text(t, _, _) = item { return t } else { return nil }
+        }.joined(separator: "\n")
+    }
+
+    // MARK: - Tests
+
+    /// Direct mode source + Session mode target → atEnd splice succeeds, returns 1.
+    func testSpliceOMathFromSourcePathToTargetAtEnd() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+
+        // Open target
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t1")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t1"),
+                "target_paragraph_index": .int(0),
+                "position": .string("atEnd")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.contains("Spliced 1 OMath"),
+            "Expected 'Spliced 1 OMath' message; got: \(txt)"
+        )
+    }
+
+    /// afterText anchor splice succeeds.
+    func testSpliceOMathFromSourceWithAfterTextAnchor() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t2")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t2"),
+                "target_paragraph_index": .int(0),
+                "position": .string("afterText"),
+                "anchor": .string("所得出的參數進行 ")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.contains("Spliced 1 OMath"),
+            "Expected 'Spliced 1 OMath' message; got: \(txt)"
+        )
+    }
+
+    /// Missing required arg → structured error.
+    func testMissingPositionArgReturnsError() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t3")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t3"),
+                "target_paragraph_index": .int(0)
+                // position missing
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertFalse(txt.contains("Spliced"), "Should not succeed without position")
+    }
+
+    /// afterText without anchor → structured error.
+    func testAfterTextWithoutAnchorReturnsError() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t4")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t4"),
+                "target_paragraph_index": .int(0),
+                "position": .string("afterText")
+                // anchor missing
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.lowercased().contains("anchor"),
+            "Expected error mentioning 'anchor'; got: \(txt)"
+        )
+    }
+
+    /// omath_index out of range → structured error.
+    func testOMathIndexOutOfRange() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t5")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t5"),
+                "target_paragraph_index": .int(0),
+                "position": .string("atEnd"),
+                "omath_index": .int(99)
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.lowercased().contains("out of range"),
+            "Expected 'out of range' error for omath_index=99; got: \(txt)"
+        )
+    }
+
+    /// Source paragraph with no OMath → structured error.
+    func testSourceWithNoOMathReturnsError() async throws {
+        // Build source with only text (no OMath)
+        var sourceDoc = WordDocument()
+        var run = Run(text: "no math here")
+        run.position = 1
+        sourceDoc.body.children.append(.paragraph(Paragraph(runs: [run])))
+        let sourceURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue160-no-omath-\(UUID().uuidString).docx")
+        try DocxWriter.write(sourceDoc, to: sourceURL)
+
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t6")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t6"),
+                "target_paragraph_index": .int(0),
+                "position": .string("atEnd")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.lowercased().contains("no omath"),
+            "Expected 'no OMath' error; got: \(txt)"
+        )
+    }
+
+    /// Paragraph-level batch splice succeeds.
+    func testSpliceParagraphOMathFromSource() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t7")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_paragraph_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t7"),
+                "target_paragraph_index": .int(0)
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.contains("Spliced 1 OMath block"),
+            "Expected 'Spliced 1 OMath block' message; got: \(txt)"
+        )
+    }
+
+    /// rpr_mode=discard works.
+    func testRpRModeDiscard() async throws {
+        let sourceURL = try makeSourceDocxWithInlineOMath()
+        let targetURL = try makeTargetDocxNoOMath()
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: targetURL)
+        }
+        let server = await WordMCPServer()
+        _ = await server.invokeToolForTesting(
+            name: "open_document",
+            arguments: ["path": .string(targetURL.path), "doc_id": .string("t8")]
+        )
+
+        let r = await server.invokeToolForTesting(
+            name: "splice_omath_from_source",
+            arguments: [
+                "source_path": .string(sourceURL.path),
+                "source_paragraph_index": .int(0),
+                "doc_id": .string("t8"),
+                "target_paragraph_index": .int(0),
+                "position": .string("atEnd"),
+                "rpr_mode": .string("discard")
+            ]
+        )
+        let txt = textOf(r)
+        XCTAssertTrue(
+            txt.contains("Spliced 1 OMath") && txt.contains("rpr_mode=discard"),
+            "Expected 'Spliced 1 OMath' and 'rpr_mode=discard'; got: \(txt)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Refs #160. Implements two MCP tools wrapping [PsychQuant/ooxml-swift v0.24.0's spliceOMath API](https://github.com/PsychQuant/ooxml-swift/issues/57) to enable cross-document verbatim copy of `<m:oMath>` XML blocks via MCP transport.

Unblocks the kiki830621/collaboration_guo_analysis Phase 7 inline-math restoration workflow (already deployed locally; this PR makes the API available to other MCP callers — Claude Code sessions, future automation scripts).

## New tools

### `splice_omath_from_source` (single-OMath, low-level)

```typescript
{
  source_path?: string,         // Direct mode (read-only)
  source_doc_id?: string,       // OR Session mode
  source_paragraph_index: number,
  doc_id: string,
  target_paragraph_index: number,
  position: "atStart" | "atEnd" | "afterText" | "beforeText",
  anchor?: string,              // required for afterText / beforeText
  instance?: number,            // 1-based (default 1)
  omath_index?: number,         // joint document-order index (default 0)
  rpr_mode?: "full" | "omathOnly" | "discard",  // default "full"
  namespace_policy?: "lenient" | "strict"        // default "lenient"
}
```

### `splice_paragraph_omath_from_source` (paragraph-level batch, high-level)

Same surface minus `position` / `anchor` / `instance` / `omath_index` — splices ALL OMath blocks from source paragraph in source-document order, auto-deriving anchor via ~10-char source-text-context.

## Test plan

- [x] `Issue160SpliceOMathFromSourceTests` — 8 test cases:
  - Direct mode (`source_path`) → Session mode (`doc_id`) splice atEnd
  - `afterText` anchor splice
  - Missing required args → structured errors
  - `omath_index` out of range
  - Source paragraph with no OMath
  - Paragraph-level batch
  - `rpr_mode=discard` end-to-end
- [x] Full suite: 297 tests, 0 failures, 9 pre-existing skips

## Dependencies

- Bumps `ooxml-swift`: `0.21.0` → `0.24.0` (required for `spliceOMath` API)

## Out of scope (deferred)

- Direct-mode for target side — target requires Session mode (`doc_id`) because splice mutates the document
- Splice into headers/footers/footnotes/endnotes — body paragraphs only (matches ooxml-swift v0.24.0's API surface)
- Document-level batch (`splice_all_omath_from_source`) — paragraph matching strategy is caller-specific (rescue script uses 30-char prefix anchors; other callers may want different matchers)

## Closes

#160